### PR TITLE
Release May 30 2024 (#127) back to staging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,13 +22,7 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
           packageMode: true
           unityVersion: '2021.3.24f1'
           projectPath: temporal_repo_folder
           artifactsPath: 'artifacts'
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: Test results
-          path: ${{ steps.test-step.outputs.artifactsPath }}

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Ignore temporaries from GameCI
+/[Aa]rtifacts/
+/[Cc]odeCoverage/

--- a/Tests/PlayMode/PlayMode.romulo_Tests.asmdef
+++ b/Tests/PlayMode/PlayMode.romulo_Tests.asmdef
@@ -27,8 +27,7 @@
     "overrideReferences": true,
     "precompiledReferences": [
         "nunit.framework.dll",
-        "Newtonsoft.Json.dll",
-        "Newtonsoft.Json.Schema.dll"
+        "Newtonsoft.Json.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.reup.romulo",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "displayName": "Romulo",
   "description": "This package contains the assets to create virtual twins of properties for the ReUp platform.",
   "unity": "2019.1",


### PR DESCRIPTION
* fixing delete manager to delete based on id

* changing method name, avoiding returning null

* Fix camera selecting character intead of material picker

* apply fix to extension triggers

* Improve DummpyJsonCreator

* feat: select object after insertion

BREAKING CHANGE: changed the payload sent to unity to insert furniture from an string (the fbx url) to an object with the interface `{objectUrl: string, selectObjectAfterInsertion: boolean, deselectPreviousSelection: boolean}`

* Pass object id to insert object manager

* commit

* Add change color dependency injector

* Drop the paintable tag and update to receive a list of objects ids to paint, alongside the RGB color to apply

* changing color on children objects with tests

* Modified change color manager and tests

* Assign new id to inserted object

* Delete 's'

* Add missing tests

* Fix identifier typo

* Update Runtime/Enums/ObjectTag.cs

Delete paintable tag



* Use string instead of enum as tags

* Changed ReupEvent to objectColorChanged

* Refactor to ChangeObjectsColor

* Delete tags controller and unused libraries

* Create custom ObjectTag Editor

* ObjectRegistry update

* Utils update

* Tests updated

* Check when user reach bottom of tags

* Create Tags Api Manager

* Fetching Tags

* Rename EditionTag

* use strings instead of tags enum

* Clean up

* Remove FinderController

* Clean code

* Create InsertObjectController

* First test of InsertObjectController

* Implement InsertObjectController in EditionMediator

* Send InsertedObjectPayload to mediator

* Add Test for Tags in inserted object

* Fix Edition Mediator to use new Insert Object Controller

* Add colliders to inserted object

* Add simultanious insertion tests

* Clean and remove unnused code

* Fix comments

* Delete the MonoBehaviour inheritance from the CharacterColliderBoxController

Also update the DestroyCollider() method as it was using the Destroy() method from the MonoBehaviourr inheritance.

* Create StubOnSetupBuildingCreator

* Create IBuilddingGetter interface

* Get SendStartupMessage with tests

* Fix web message sender not ready yet

* REUP-241 Make drop down menu smaller

* Test fixed

* Update prefab name

* Update mediator

* Create Reup prefab test file

* modify the setup and the teardown methods to of the IdControllerTest to make sure that the objectRegistryGameObject is created and erased before and after each test.

* Modifies the setup and teardown methods of the IdControllerTest, ObjectRegistryTest and RegisteredIdentifierTest.

Ensures that the objectRegistryGameObject is created and deleted before and after each test, taking care of asynchronous  operations.

* Fix set up building

* Fix minor details

* Move IRegistry from models folder to modelsInterface Folder.

Also, updates the dependency injector assembly to include the modelsInterface assembly, ensuring that the IRegistry interface can be used without problems.

* Update all code dependent on IRegistry interface

* Change the input movement keys

The user can walk straight with the up and down arrow keys. The user can rotate the view with the left and right arrow keys. The user can walk straight and sideways with the WASD keys. No other movement keys are affected.

* tags url now lives in ObjectTags script, not in editor script

* Update Runtime/Managers/ChangeColorManager.cs

* Add the UnityTearDown method to enable yielding during objectRegistry destruction in teardown phase

* Change to new material with color

* Fix initial objects position inside reup prefab

* Put mocks before tests

* Create ChangeMaterialController

* Fix version

* Move TagsWebRequesterControlle

* Move TagsApiConsumer to web requester folder

* Address commments

* Create TExtureDownloader

* Move RegistrySpy

* Rename IobjectRegistry

* Change materials of objects

* Create assign texture test

* Comments addressed

* Comments addressed

* Test to apply downloaded material

* Implement Texture Downloader

* Delegate change material from mediator to controller

* Make test classes private in InsertObjectControllerTest

* Rename variables

* Notify mediator when object materials change

* Send message when material are changed

* Fix minnor prefab error

* Remove unnused property

* Remove old code

* Fix movement input keys

* Fix multiple tag fetch

* Change action tags

* Create test workflow

* modify move to tmp folder step

* not checking out folders

* remove sparse-checkout

* Deleting most of the code

* rename main.yml

* remove comments

* publish results

* end list and failing test

* publish test in comment

* remove coverage logic

* remove failing test

* define which .xml files to publish

* Revert "Deleting most of the code"

This reverts commit fa8c1ac0f73cf87719fc290fb013b8982acdecf0.

* remove webgl ifs

* remove UNITY_WEBGL if

* Add unity mesh simplifier dependency

* Revert "Add unity mesh simplifier dependency"

This reverts commit 88cade816b56e29169fd9c487c8c82ce496a6934.

* Add UnityMeshSimplifer code to package

* rename test.yml

* remove unnecessary lines

* move behaviour interfaces to right folder

* Move Utils to helpers folders

* restaurate SimplifyMesh

* Change the startupMessage for the 3 way handshake comunication

* Adjustments

* Adjustments

* Adjustments

* Adjustements

* Tests for the ModelInfoManager

* update IObjectRegistry name

* return material url as part of response

* Handle error when error happens when attempt to downlaod texture fails

* Automate Unity builds using a C# script

* Update Runtime/Helpers/Utils.cs



* Save Tag objects instead of just tag names

* Set all positions to 0 in Reup prefab

* update package version

* Comments addressed

* rename actions that send object data to angular

* Create data manipulation helpers

* Remove test workflows

* Add array support

* return types of values

* Make new payload format work

* Just remove publish step

This reverts commit 23bc14ec0626c443ae1514c516dafb7d57c6005a.

* not working because fighting JObject

* Use JObject in Change material controller

* Make Edition Mediator use JObject

* Clean

* Add Validation to Incoming messages

* Receive boolean when setting edit mode

* expect JObject as notification payload when material change

* use same syntax for schemas

* send change color success message

* fix auto builder

* Create First version of Validator

* Validate nested objects

* implement structured schemas

* Add warning log with key name

* Add Validation to JValues

* Validate objects against other types

* something

* Create IncomingMessageValidator

* Register incoming messages

* Clean

* Staging (#123)

* fixing delete manager to delete based on id

* changing method name, avoiding returning null

* Fix camera selecting character intead of material picker

* apply fix to extension triggers

* Improve DummpyJsonCreator

* feat: select object after insertion

BREAKING CHANGE: changed the payload sent to unity to insert furniture from an string (the fbx url) to an object with the interface `{objectUrl: string, selectObjectAfterInsertion: boolean, deselectPreviousSelection: boolean}`

* Pass object id to insert object manager

* commit

* Add change color dependency injector

* Drop the paintable tag and update to receive a list of objects ids to paint, alongside the RGB color to apply

* changing color on children objects with tests

* Modified change color manager and tests

* Assign new id to inserted object

* Delete 's'

* Add missing tests

* Fix identifier typo

* Update Runtime/Enums/ObjectTag.cs

Delete paintable tag



* Use string instead of enum as tags

* Changed ReupEvent to objectColorChanged

* Refactor to ChangeObjectsColor

* Delete tags controller and unused libraries

* Create custom ObjectTag Editor

* ObjectRegistry update

* Utils update

* Tests updated

* Check when user reach bottom of tags

* Create Tags Api Manager

* Fetching Tags

* Rename EditionTag

* use strings instead of tags enum

* Clean up

* Remove FinderController

* Clean code

* Create InsertObjectController

* First test of InsertObjectController

* Implement InsertObjectController in EditionMediator

* Send InsertedObjectPayload to mediator

* Add Test for Tags in inserted object

* Fix Edition Mediator to use new Insert Object Controller

* Add colliders to inserted object

* Add simultanious insertion tests

* Clean and remove unnused code

* Fix comments

* Delete the MonoBehaviour inheritance from the CharacterColliderBoxController

Also update the DestroyCollider() method as it was using the Destroy() method from the MonoBehaviourr inheritance.

* Create StubOnSetupBuildingCreator

* Create IBuilddingGetter interface

* Get SendStartupMessage with tests

* Fix web message sender not ready yet

* REUP-241 Make drop down menu smaller

* Test fixed

* Update prefab name

* Update mediator

* Create Reup prefab test file

* modify the setup and the teardown methods to of the IdControllerTest to make sure that the objectRegistryGameObject is created and erased before and after each test.

* Modifies the setup and teardown methods of the IdControllerTest, ObjectRegistryTest and RegisteredIdentifierTest.

Ensures that the objectRegistryGameObject is created and deleted before and after each test, taking care of asynchronous  operations.

* Fix set up building

* Fix minor details

* Move IRegistry from models folder to modelsInterface Folder.

Also, updates the dependency injector assembly to include the modelsInterface assembly, ensuring that the IRegistry interface can be used without problems.

* Update all code dependent on IRegistry interface

* Change the input movement keys

The user can walk straight with the up and down arrow keys. The user can rotate the view with the left and right arrow keys. The user can walk straight and sideways with the WASD keys. No other movement keys are affected.

* tags url now lives in ObjectTags script, not in editor script

* Update Runtime/Managers/ChangeColorManager.cs

* Add the UnityTearDown method to enable yielding during objectRegistry destruction in teardown phase

* Change to new material with color

* Fix initial objects position inside reup prefab

* Put mocks before tests

* Create ChangeMaterialController

* Fix version

* Move TagsWebRequesterControlle

* Move TagsApiConsumer to web requester folder

* Address commments

* Create TExtureDownloader

* Move RegistrySpy

* Rename IobjectRegistry

* Change materials of objects

* Create assign texture test

* Comments addressed

* Comments addressed

* Test to apply downloaded material

* Implement Texture Downloader

* Delegate change material from mediator to controller

* Make test classes private in InsertObjectControllerTest

* Rename variables

* Notify mediator when object materials change

* Send message when material are changed

* Fix minnor prefab error

* Remove unnused property

* Remove old code

* Fix movement input keys

* Fix multiple tag fetch

* Change action tags

* Create test workflow

* modify move to tmp folder step

* not checking out folders

* remove sparse-checkout

* Deleting most of the code

* rename main.yml

* remove comments

* publish results

* end list and failing test

* publish test in comment

* remove coverage logic

* remove failing test

* define which .xml files to publish

* Revert "Deleting most of the code"

This reverts commit fa8c1ac0f73cf87719fc290fb013b8982acdecf0.

* remove webgl ifs

* remove UNITY_WEBGL if

* Add unity mesh simplifier dependency

* Revert "Add unity mesh simplifier dependency"

This reverts commit 88cade816b56e29169fd9c487c8c82ce496a6934.

* Add UnityMeshSimplifer code to package

* rename test.yml

* remove unnecessary lines

* move behaviour interfaces to right folder

* Move Utils to helpers folders

* restaurate SimplifyMesh

* Change the startupMessage for the 3 way handshake comunication

* Adjustments

* Adjustments

* Adjustments

* Adjustements

* Tests for the ModelInfoManager

* update IObjectRegistry name

* return material url as part of response

* Handle error when error happens when attempt to downlaod texture fails

* Automate Unity builds using a C# script

* Update Runtime/Helpers/Utils.cs



* Save Tag objects instead of just tag names

* Set all positions to 0 in Reup prefab

* update package version

* Comments addressed

* rename actions that send object data to angular

* Create data manipulation helpers

* Remove test workflows

* Add array support

* return types of values

* Make new payload format work

* Just remove publish step

This reverts commit 23bc14ec0626c443ae1514c516dafb7d57c6005a.

* not working because fighting JObject

* Use JObject in Change material controller

* Make Edition Mediator use JObject

* Clean

* Add Validation to Incoming messages

* Receive boolean when setting edit mode

* expect JObject as notification payload when material change

* use same syntax for schemas

* send change color success message

* fix auto builder

* Create First version of Validator

* Validate nested objects

* implement structured schemas

* Add warning log with key name

* Add Validation to JValues

* Validate objects against other types

* something

* Create IncomingMessageValidator

* Register incoming messages

* Clean

---------






* new Version (#124)



* add permissions

* publish tests results

* only run test

* Change versiont from 1.1.2 to 1.1.3

---------