### PR TITLE
Accept multi schema in Data Validator

### DIFF
--- a/Runtime/DataSchemas/RomuloExternalSchema.cs
+++ b/Runtime/DataSchemas/RomuloExternalSchema.cs
@@ -12,7 +12,7 @@ namespace ReupVirtualTwin.dataSchemas
                 {
                     { "material_id", DataValidator.intSchema },
                     { "material_url", DataValidator.stringSchema },
-                    { "object_ids", DataValidator.CreateArraySchema(new JObject[] { DataValidator.stringSchema }) },
+                    { "object_ids", DataValidator.CreateArraySchema(DataValidator.stringSchema) },
                 }
             },
             { "required", new JArray { "material_url", "object_ids", "material_id" } },

--- a/Runtime/DataSchemas/RomuloInternalSchema.cs
+++ b/Runtime/DataSchemas/RomuloInternalSchema.cs
@@ -18,7 +18,7 @@ namespace ReupVirtualTwin.dataSchemas
                     {
                         { "material_id", DataValidator.intSchema },
                         { "material_url", DataValidator.stringSchema },
-                        { "object_ids",  DataValidator.CreateArraySchema(new JObject[] { DataValidator.stringSchema })},
+                        { "object_ids",  DataValidator.CreateArraySchema(DataValidator.stringSchema)},
                     }
                 },
                 { "required", new JArray { "material_url", "object_ids", "material_id" } }
@@ -43,8 +43,7 @@ namespace ReupVirtualTwin.dataSchemas
                     {
                         { "id", DataValidator.stringSchema },
                         { "appearance", sceneStateAppearanceSchema },
-                        { "children", DataValidator.CreateArraySchema(new JObject[]
-                            { DataValidator.CreateRefSchema("sceneStateSchema") })
+                        { "children", DataValidator.CreateArraySchema(DataValidator.CreateRefSchema("sceneStateSchema"))
                         },
                     }
                 },

--- a/Runtime/Helpers/DataValidator.cs
+++ b/Runtime/Helpers/DataValidator.cs
@@ -29,6 +29,18 @@ namespace ReupVirtualTwin.helpers
         {
             { "type", boolType }
         };
+        public static readonly JObject nullSchema = new JObject
+        {
+            { "type", null }
+        };
+
+        static public JObject MultiSchema(params JObject[] schemas)
+        {
+            return new JObject
+            {
+                { "oneOf", new JArray(schemas) }
+            };
+        }
 
         static public JObject CreateRefSchema(string refName)
         {
@@ -71,6 +83,10 @@ namespace ReupVirtualTwin.helpers
             {
                 return false;
             }
+            if (schema["oneOf"] != null)
+            {
+                return ValidateJTokenToAnySchema(obj, (JArray)schema["oneOf"]);
+            }
             switch ((string)schema["type"])
             {
                 case boolType:
@@ -85,10 +101,16 @@ namespace ReupVirtualTwin.helpers
                     return ValidateJArrayItems(obj, (JArray)schema["items"]);
                 case schemaRefType:
                     return ValidateObjectToSchemaRef(obj, schema);
+                case null:
+                    return ValidateToNull(obj);
                 default:
                     Debug.LogWarning($"Type {schema["type"]} not supported");
                     return false;
             }
+        }
+        static bool ValidateToNull(JToken obj)
+        {
+            return obj.Type == JTokenType.Null;
         }
         static bool ValidateObjectToSchemaRef(JToken obj, JObject schemaRef)
         {

--- a/Runtime/Helpers/DataValidator.cs
+++ b/Runtime/Helpers/DataValidator.cs
@@ -51,7 +51,7 @@ namespace ReupVirtualTwin.helpers
             };
         }
 
-        static public JObject CreateArraySchema(JObject[] itemSchemas)
+        static public JObject CreateArraySchema(params JObject[] itemSchemas)
         {
             return new JObject
             {

--- a/Tests/PlayMode/DataValidatorTest.cs
+++ b/Tests/PlayMode/DataValidatorTest.cs
@@ -313,4 +313,27 @@ public class DataValidatorTest
         Assert.IsFalse(result);
     }
 
+    [Test]
+    public void ValidateObjectShouldSuccess_for_multiOptionTypes()
+    {
+        JObject multiSchema = DataValidator.MultiSchema(DataValidator.intSchema, DataValidator.stringSchema);
+        bool result;
+        result = DataValidator.ValidateObjectToSchema(5, multiSchema);
+        Assert.IsTrue(result);
+        result = DataValidator.ValidateObjectToSchema("this is a string", multiSchema);
+        Assert.IsTrue(result);
+        result = DataValidator.ValidateObjectToSchema(null, multiSchema);
+        Assert.IsFalse(result);
+    }
+
+    [Test]
+    public void ValidateShouldAcceptNullSchema()
+    {
+        bool result;
+        result = DataValidator.ValidateObjectToSchema("this is a string", DataValidator.nullSchema);
+        Assert.IsFalse(result);
+        result = DataValidator.ValidateObjectToSchema(null, DataValidator.nullSchema);
+        Assert.IsTrue(result);
+    }
+
 }

--- a/Tests/PlayMode/DataValidatorTest.cs
+++ b/Tests/PlayMode/DataValidatorTest.cs
@@ -50,7 +50,7 @@ public class DataValidatorTest
                 }
             }
         };
-        intStringArraySchema = DataValidator.CreateArraySchema(new JObject[] { DataValidator.intSchema, DataValidator.stringSchema });
+        intStringArraySchema = DataValidator.CreateArraySchema(DataValidator.intSchema, DataValidator.stringSchema);
     }
 
     [Test]

--- a/Tests/PlayMode/DataValidatorTest.cs
+++ b/Tests/PlayMode/DataValidatorTest.cs
@@ -336,4 +336,65 @@ public class DataValidatorTest
         Assert.IsTrue(result);
     }
 
+    [Test]
+    public void ShouldSuccessValidation_when_nullIsOptionOfMultiSchema()
+    {
+        JObject multiSchema = DataValidator.MultiSchema(DataValidator.intSchema, DataValidator.nullSchema);
+        bool result;
+        result = DataValidator.ValidateObjectToSchema(5, multiSchema);
+        Assert.IsTrue(result);
+        result = DataValidator.ValidateObjectToSchema(null, multiSchema);
+        Assert.IsTrue(result);
+    }
+
+    [Test]
+    public void ShouldFailValidation_when_nullIsOptionOfMultiSchema()
+    {
+        JObject multiSchema = DataValidator.MultiSchema(DataValidator.intSchema, DataValidator.nullSchema);
+        bool result;
+        result = DataValidator.ValidateObjectToSchema("this is a string", multiSchema);
+        Assert.IsFalse(result);
+    }
+
+    [Test]
+    public void ShouldSuccessValidation_when_MultiSchemaIsInObjectKey()
+    {
+        JObject schema = new JObject
+        {
+            { "type", DataValidator.objectType },
+            { "properties", new JObject
+                {
+                    { "the_int", DataValidator.MultiSchema(DataValidator.intSchema, DataValidator.nullSchema) },
+                    { "the_null", DataValidator.MultiSchema(DataValidator.intSchema, DataValidator.nullSchema) },
+                }
+            }
+        };
+        Dictionary<string, object> data = new Dictionary<string, object>
+        {
+            { "the_int", 5 },
+            { "the_null", null }
+        };
+        bool result = DataValidator.ValidateObjectToSchema(data, schema);
+        Assert.IsTrue(result);
+    }
+
+    [Test]
+    public void ShouldFailValidation_when_MultiSchemaIsInObjectKey()
+    {
+        JObject schema = new JObject
+        {
+            { "type", DataValidator.objectType },
+            { "properties", new JObject
+                {
+                    { "the_float", DataValidator.MultiSchema(DataValidator.intSchema, DataValidator.nullSchema) },
+                }
+            }
+        };
+        Dictionary<string, object> data = new Dictionary<string, object>
+        {
+            { "the_float", 5.1 },
+        };
+        bool result = DataValidator.ValidateObjectToSchema(data, schema);
+        Assert.IsFalse(result);
+    }
 }


### PR DESCRIPTION
In this PR:
- implement multi schema in DataValidator (equivalent to "oneOf" in json schema)
- accept null values
- simplify the call on schema creator methods