### PR TITLE
Release Jun 28-2024 (#139)

### DIFF
--- a/Runtime/Controllers/ChangeMaterialController.cs
+++ b/Runtime/Controllers/ChangeMaterialController.cs
@@ -51,6 +51,7 @@ namespace ReupVirtualTwin.controllers
                 if (objects[i].GetComponent<Renderer>() != null)
                 {
                     objects[i].GetComponent<Renderer>().material = newMaterial;
+                    ObjectMetaDataUtils.AssignMaterialIdMetaDataToObject(objects[i], message["material_id"].ToObject<int>());
                 }
             }
             mediator.Notify(ReupEvent.objectMaterialChanged, message);

--- a/Runtime/Controllers/IdController.cs
+++ b/Runtime/Controllers/IdController.cs
@@ -1,8 +1,8 @@
-using ReupVirtualTwin.models;
 using UnityEngine;
 using ReupVirtualTwin.modelInterfaces;
 using ReupVirtualTwin.controllerInterfaces;
 using System.Collections.Generic;
+using ReupVirtualTwin.models;
 
 namespace ReupVirtualTwin.controllers
 {

--- a/Runtime/DataModels/Tag.cs
+++ b/Runtime/DataModels/Tag.cs
@@ -8,5 +8,6 @@ namespace ReupVirtualTwin.dataModels
         public string id;
         public string name;
         public string description;
+        public int priority;
     }
 }

--- a/Runtime/DataSchemas/RomuloExternalSchema.cs
+++ b/Runtime/DataSchemas/RomuloExternalSchema.cs
@@ -10,11 +10,23 @@ namespace ReupVirtualTwin.dataSchemas
             { "type", DataValidator.objectType },
             { "properties", new JObject
                 {
+                    { "material_id", DataValidator.intSchema },
                     { "material_url", DataValidator.stringSchema },
                     { "object_ids", DataValidator.CreateArraySchema(new JObject[] { DataValidator.stringSchema }) },
                 }
             },
-            { "required", new JArray { "material_url", "object_ids" } },
+            { "required", new JArray { "material_url", "object_ids", "material_id" } },
+        };
+
+        public static readonly JObject requestSceneStatePayloadSchema = new JObject
+        {
+            { "type", DataValidator.objectType },
+            { "properties", new JObject
+                {
+                    { "scene_name", DataValidator.stringSchema },
+                }
+            },
+            { "required", new JArray { "scene_name" } },
         };
     }
 }

--- a/Runtime/DataSchemas/RomuloInternalSchema.cs
+++ b/Runtime/DataSchemas/RomuloInternalSchema.cs
@@ -5,16 +5,54 @@ namespace ReupVirtualTwin.dataSchemas
 {
     public static class RomuloInternalSchema
     {
-        public static readonly JObject materialChangeInfo = new()
+        public static JObject materialChangeInfo { get; private set; }
+        public static JObject sceneStateSchema { get; private set; }
+        public static JObject sceneStateAppearanceSchema { get; private set; }
+
+        static RomuloInternalSchema()
         {
-            { "type", DataValidator.objectType },
-            { "properties", new JObject
-                {
-                    { "material_url", DataValidator.stringSchema },
-                    { "object_ids",  DataValidator.CreateArraySchema(new JObject[] { DataValidator.stringSchema })},
+            materialChangeInfo = new()
+            {
+                { "type", DataValidator.objectType },
+                { "properties", new JObject
+                    {
+                        { "material_id", DataValidator.intSchema },
+                        { "material_url", DataValidator.stringSchema },
+                        { "object_ids",  DataValidator.CreateArraySchema(new JObject[] { DataValidator.stringSchema })},
+                    }
+                },
+                { "required", new JArray { "material_url", "object_ids", "material_id" } }
+            };
+
+            sceneStateAppearanceSchema = new()
+            {
+                { "type", DataValidator.objectType },
+                { "properties", new JObject
+                    {
+                        { "color", DataValidator.stringSchema },
+                        { "material_id", DataValidator.stringSchema}
+                    }
                 }
-            },
-            { "required", new JArray { "material_url", "object_ids" } }
-        };
+            };
+
+            sceneStateSchema = new()
+            {
+                { "type", DataValidator.objectType },
+                { "name", "sceneStateSchema" },
+                { "properties", new JObject
+                    {
+                        { "id", DataValidator.stringSchema },
+                        { "appearance", sceneStateAppearanceSchema },
+                        { "children", DataValidator.CreateArraySchema(new JObject[]
+                            { DataValidator.CreateRefSchema("sceneStateSchema") })
+                        },
+                    }
+                },
+                { "required", new JArray { "id" } }
+            };
+
+        }
+
+
     }
 }

--- a/Runtime/Enums/WebMessageType.cs
+++ b/Runtime/Enums/WebMessageType.cs
@@ -36,5 +36,8 @@ namespace ReupVirtualTwin.enums
         public const string requestModelInfoSuccess = "[Initial Load Request] Request ModelInfo Success v2";
 
         public const string updateBuilding = "[Update Building] Update Building Success";
+
+        public const string requestSceneState = "[Model Info] Request Scene State";
+        public const string requestSceneStateSuccess = "[Model Info] Request Scene State Success";
     }
 }

--- a/Runtime/HelperInterfaces/IObjectMapper.cs
+++ b/Runtime/HelperInterfaces/IObjectMapper.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using ReupVirtualTwin.dataModels;
 using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 
 namespace ReupVirtualTwin.helperInterfaces
 {
@@ -9,5 +10,7 @@ namespace ReupVirtualTwin.helperInterfaces
         public ObjectDTO MapObjectToDTO(GameObject obj);
         public ObjectDTO[] MapObjectsToDTO(List<GameObject> objs);
         public ObjectDTO MapObjectTree(GameObject obj);
+        public JObject GetTreeSceneState(GameObject obj);
+        public JObject GetObjectSceneState(GameObject obj);
     }
 }

--- a/Runtime/Helpers/DataValidator.cs
+++ b/Runtime/Helpers/DataValidator.cs
@@ -14,6 +14,9 @@ namespace ReupVirtualTwin.helpers
         public const string objectType = "object";
         public const string arrayType = "array";
 
+        private const string referredSchemaKey = "referredSchema";
+        private const string schemaRefType = "$schemaRef";
+
         public static readonly JObject stringSchema = new()
         {
             { "type", stringType }
@@ -27,6 +30,15 @@ namespace ReupVirtualTwin.helpers
             { "type", boolType }
         };
 
+        static public JObject CreateRefSchema(string refName)
+        {
+            return new JObject
+            {
+                { "type", schemaRefType },
+                { referredSchemaKey, refName }
+            };
+        }
+
         static public JObject CreateArraySchema(JObject[] itemSchemas)
         {
             return new JObject
@@ -36,10 +48,10 @@ namespace ReupVirtualTwin.helpers
             };
         }
 
-        static public bool ValidateObjectToSchema(object obj, JObject schemaKeys)
+        static public bool ValidateObjectToSchema(object obj, JObject schema)
         {
             string json = JsonConvert.SerializeObject(obj);
-            return ValidateJsonStringToSchema(json, schemaKeys);
+            return ValidateJsonStringToSchema(json, schema);
         }
 
         static public bool ValidateJsonStringToSchema(string json, JObject schema)
@@ -48,13 +60,17 @@ namespace ReupVirtualTwin.helpers
             return ValidateJTokenToSchema(jsonObj, schema);
         }
 
-        static private bool ValidateJTokenToSchema(JToken obj, JObject schema)
+        static bool ValidateJTokenToSchema(JToken obj, JObject schema)
         {
             return ValidateJTokenToSchema(obj, schema, "");
         }
 
-        static private bool ValidateJTokenToSchema(JToken obj, JObject schema, string key)
+        static bool ValidateJTokenToSchema(JToken obj, JObject schema, string key)
         {
+            if (schema == null)
+            {
+                return false;
+            }
             switch ((string)schema["type"])
             {
                 case boolType:
@@ -67,12 +83,40 @@ namespace ReupVirtualTwin.helpers
                     return ValidateJObjectProperties(obj, schema);
                 case arrayType:
                     return ValidateJArrayItems(obj, (JArray)schema["items"]);
+                case schemaRefType:
+                    return ValidateObjectToSchemaRef(obj, schema);
                 default:
                     Debug.LogWarning($"Type {schema["type"]} not supported");
                     return false;
             }
         }
-        static private bool ValidateJArrayItems(JToken array, JArray acceptedSchemas)
+        static bool ValidateObjectToSchemaRef(JToken obj, JObject schemaRef)
+        {
+            JObject referredSchema = GetReferredSchemaFromInnerSchema(schemaRef, (string)schemaRef[referredSchemaKey]);
+            return ValidateJTokenToSchema(obj, referredSchema);
+        }
+        static JObject GetReferredSchemaFromInnerSchema(JContainer innerSchema, string refSchemaName)
+        {
+            if (innerSchema == null)
+            {
+                Debug.LogWarning($"Could not find reference to {refSchemaName}");
+                return null;
+            }
+            JContainer parentObj = innerSchema.Parent;
+            if (IsJObjectReferredSchema(parentObj, refSchemaName))
+            {
+                return (JObject)parentObj;
+            }
+            return GetReferredSchemaFromInnerSchema(parentObj, refSchemaName);
+        }
+        static bool IsJObjectReferredSchema(JContainer container, string refSchemaName)
+        {
+            return container != null &&
+                container is JObject &&
+                container["name"] != null &&
+                container["name"].ToString() == refSchemaName;
+        }
+        static bool ValidateJArrayItems(JToken array, JArray acceptedSchemas)
         {
             if (!ValidateJObjectType(array, JTokenType.Array))
             {
@@ -88,7 +132,7 @@ namespace ReupVirtualTwin.helpers
             }
             return true;
         }
-        static private bool ValidateJTokenToAnySchema(JToken obj, JArray schemas)
+        static bool ValidateJTokenToAnySchema(JToken obj, JArray schemas)
         {
             foreach (JToken schema in schemas)
             {
@@ -99,7 +143,7 @@ namespace ReupVirtualTwin.helpers
             }
             return false;
         }
-        static private bool ValidateJObjectProperties(JToken obj, JObject schema)
+        static bool ValidateJObjectProperties(JToken obj, JObject schema)
         {
             JObject properties = (JObject)schema["properties"];
             JArray required = (JArray)schema["required"];
@@ -109,7 +153,7 @@ namespace ReupVirtualTwin.helpers
             }
             foreach (KeyValuePair<string, JToken> pair in properties)
             {
-                if (obj[pair.Key] == null && ItemInArray<string>(required, pair.Key))
+                if (obj[pair.Key] == null && IsItemInArray<string>(required, pair.Key))
                 {
                     Debug.LogWarning($"Key {pair.Key} not found in object");
                     return false;
@@ -123,7 +167,7 @@ namespace ReupVirtualTwin.helpers
             return true;
         }
 
-        static private bool ValidateJObjectType(JToken obj, JTokenType expectedType, string key)
+        static bool ValidateJObjectType(JToken obj, JTokenType expectedType, string key)
         {
             bool valid = ValidateJObjectType(obj, expectedType);
             if (!valid && !string.IsNullOrEmpty(key))
@@ -133,7 +177,7 @@ namespace ReupVirtualTwin.helpers
             return valid;
         }
 
-        static private bool ValidateJObjectType(JToken obj, JTokenType expectedType)
+        static bool ValidateJObjectType(JToken obj, JTokenType expectedType)
         {
             if (obj.Type != expectedType)
             {
@@ -143,7 +187,7 @@ namespace ReupVirtualTwin.helpers
             return true;
         }
 
-        static private bool ItemInArray<T>(JArray array, T item)
+        static bool IsItemInArray<T>(JArray array, T item)
         {
             if (array == null)
             {

--- a/Runtime/Helpers/JObjectUtils.cs
+++ b/Runtime/Helpers/JObjectUtils.cs
@@ -1,0 +1,39 @@
+using Newtonsoft.Json.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace ReupVirtualTwin.helpers
+{
+    public static class JObjectUtils
+    {
+        public static JObject SetValueToPath(JObject jObj, string valuePath, object value)
+        {
+            List<string> keys = valuePath.Split('.').ToList();
+            JObject nestedObject = keys.SkipLast(1).Aggregate(jObj, (obj, key) =>
+            {
+                JObject nestedObject = obj[key] as JObject;
+                if (nestedObject == null)
+                {
+                    JObject newObj = new JObject();
+                    obj[key] = newObj;
+                    return newObj;
+                }
+                return nestedObject;
+            });
+            nestedObject[keys.Last()] = JToken.FromObject(value);
+            return jObj;
+        }
+        public static JObject RemoveValueFromPath(JObject jObj, string valuePath)
+        {
+            JToken jValue = jObj.SelectToken(valuePath);
+            if (jValue != null)
+            {
+                jValue.Parent.Remove();
+            }
+            return jObj;
+        }
+    }
+}
+

--- a/Runtime/Helpers/JObjectUtils.cs.meta
+++ b/Runtime/Helpers/JObjectUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e992dff65e611444dbee87ffee063287
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Helpers/ObjectMapper.cs
+++ b/Runtime/Helpers/ObjectMapper.cs
@@ -5,6 +5,7 @@ using ReupVirtualTwin.dataModels;
 using ReupVirtualTwin.helperInterfaces;
 using ReupVirtualTwin.modelInterfaces;
 using ReupVirtualTwin.controllerInterfaces;
+using Newtonsoft.Json.Linq;
 
 namespace ReupVirtualTwin.helpers
 {
@@ -33,7 +34,7 @@ namespace ReupVirtualTwin.helpers
             return new ObjectDTO
             {
                 id = _idGetterController.GetIdFromObject(obj),
-                tags = _tagsController.GetTagsFromObject(obj).ToArray()
+                tags = _tagsController.GetTagsFromObject(obj).ToArray(),
             };
         }
 
@@ -46,6 +47,36 @@ namespace ReupVirtualTwin.helpers
                 objectDTO.children[i] = MapObjectTree(obj.transform.GetChild(i).gameObject);
             }
             return objectDTO;
+        }
+
+        public JObject GetTreeSceneState(GameObject obj)
+        {
+            JObject parentSceneState = GetObjectSceneState(obj);
+            JArray children = new JArray();
+            for(int i = 0; i < obj.transform.childCount; i++)
+            {
+                children.Add(GetTreeSceneState(obj.transform.GetChild(i).gameObject));
+            }
+            parentSceneState.Add("children", children);
+            return parentSceneState;
+        }
+
+        public JObject GetObjectSceneState(GameObject obj)
+        {
+            string objectId = _idGetterController.GetIdFromObject(obj);
+            JObject objectMetaData = ObjectMetaDataUtils.GetMetaData(obj);
+            if (objectMetaData == null)
+            {
+                return new JObject
+                {
+                    { "id", objectId },
+                };
+            }
+            return new JObject
+            {
+                { "id", objectId },
+                { "appearance", objectMetaData["appearance"] }
+            };
         }
     }
 }

--- a/Runtime/Helpers/ObjectMetadataUtils.cs
+++ b/Runtime/Helpers/ObjectMetadataUtils.cs
@@ -1,0 +1,90 @@
+using Newtonsoft.Json.Linq;
+using ReupVirtualTwin.modelInterfaces;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ReupVirtualTwin.helpers
+{
+    public static class ObjectMetaDataUtils
+    {
+        static readonly string materialIdPath = "appearance.material_id";
+        static readonly string colorPath = "appearance.color";
+        public static JObject GetMetaData(GameObject gameObject)
+        {
+            if (gameObject.TryGetComponent(out IObjectMetaDataGetterSetter objectMetaDataComponent))
+            {
+                return objectMetaDataComponent.objectMetaData;
+            }
+            return null;
+        }
+
+        public static void AssignMetaDataToObject(GameObject gameObject, JObject objectMetaData)
+        {
+            if (gameObject.TryGetComponent(out IObjectMetaDataGetterSetter objectMetaDataComponent))
+            {
+                objectMetaDataComponent.objectMetaData = objectMetaData;
+                return;
+            }
+            throw new System.Exception($"Object {gameObject.name} does not have a IObjectMetaDataGetterSetter component");
+        }
+
+        public static JToken GetMetaDataValueFromObject(GameObject gameObject, string metaDataPath)
+        {
+            JObject objectMetaData = GetMetaData(gameObject);
+            if (objectMetaData != null)
+            {
+                JToken valueToken = objectMetaData.SelectToken(metaDataPath);
+                return valueToken;
+
+            }
+            return null;
+        }
+
+        public static JObject AssignMaterialIdMetaDataToObject(GameObject gameObject, int materialId)
+        {
+            RemoveValueFromMetaDataInObject(gameObject, colorPath);
+            return AssignMetaDataValueInPathToObject(gameObject, materialIdPath, materialId);
+        }
+
+        public static JObject AssignColorMetaDataToObject(GameObject gameObject, string rgbaColor)
+        {
+            RemoveValueFromMetaDataInObject(gameObject, materialIdPath);
+            return AssignMetaDataValueInPathToObject(gameObject, colorPath, rgbaColor);
+        }
+        public static JObject RemoveValueFromMetaDataInObject(GameObject gameObject, string metaDataPath)
+        {
+            JObject objectMetaData = GetMetaData(gameObject);
+            if (objectMetaData != null)
+            {
+                JObjectUtils.RemoveValueFromPath(objectMetaData, metaDataPath);
+                return objectMetaData;
+            }
+            return null;
+        }
+        public static JObject AssignMetaDataValueInPathToObject(GameObject gameObject, string path, object value)
+        {
+            JObject objectMetaData = GetMetaData(gameObject);
+            if (objectMetaData != null)
+            {
+                JObjectUtils.SetValueToPath(objectMetaData, path, value);
+                return objectMetaData;
+            }
+            JObject newObjectMetaData = new JObject();
+            JObjectUtils.SetValueToPath(newObjectMetaData, path, value);
+            AssignMetaDataToObject(gameObject, newObjectMetaData);
+            return newObjectMetaData;
+        }
+
+        public static List<JToken> GetMetaDataValuesFromObjects(List<GameObject> objects, string metaDataPath)
+        {
+            List<JToken> metaData = new();
+            for (int i = 0; i < objects.Count; i++)
+            {
+                metaData.Add(GetMetaDataValueFromObject(objects[i], metaDataPath));
+            }
+            return metaData;
+        }
+    }
+}

--- a/Runtime/Helpers/ObjectMetadataUtils.cs.meta
+++ b/Runtime/Helpers/ObjectMetadataUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75d05fe77d9bb3f4aa5513cdaa6ab304
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Helpers/Utils.cs
+++ b/Runtime/Helpers/Utils.cs
@@ -7,7 +7,6 @@ namespace ReupVirtualTwin.helpers
     {
         public static List<string> ConvertStringToList(string idsString)
         {
-            string[] idsArray;
            if (!string.IsNullOrEmpty(idsString))
             {
                 return new List<string>(idsString.Split(','));

--- a/Runtime/ManagerInterfaces/ISceneStateManager.cs
+++ b/Runtime/ManagerInterfaces/ISceneStateManager.cs
@@ -1,0 +1,11 @@
+using Newtonsoft.Json.Linq;
+
+using ReupVirtualTwin.dataModels;
+
+namespace ReupVirtualTwin.managerInterfaces
+{
+    public interface ISceneStateManager
+    {
+        public JObject GetSceneState();
+    }
+}

--- a/Runtime/ManagerInterfaces/ISceneStateManager.cs.meta
+++ b/Runtime/ManagerInterfaces/ISceneStateManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2620148edabcbce46be1ea88f5820499
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Managers/ChangeColorManager.cs
+++ b/Runtime/Managers/ChangeColorManager.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using ReupVirtualTwin.managerInterfaces;
 using ReupVirtualTwin.enums;
 using System.Collections.Generic;
+using ReupVirtualTwin.helpers;
 
 namespace ReupVirtualTwin.managers
 {
@@ -12,14 +13,19 @@ namespace ReupVirtualTwin.managers
 
         public void ChangeObjectsColor(List<GameObject> objects, Color color)
         {
+            string rgbaColor = ColorUtility.ToHtmlStringRGBA(color);
             foreach (var obj in objects)
             {
-                ChangeObjectColor(obj, color);
+                bool changed = ChangeObjectColor(obj, color);
+                if (changed)
+                {
+                    ObjectMetaDataUtils.AssignColorMetaDataToObject(obj, rgbaColor);
+                }
             }
-            _mediator.Notify(ReupEvent.objectColorChanged);           
+            _mediator.Notify(ReupEvent.objectColorChanged);
         }
 
-        private void ChangeObjectColor(GameObject obj, Color newColor)
+        private bool ChangeObjectColor(GameObject obj, Color newColor)
         {
             Renderer renderer = obj.GetComponent<Renderer>();
             if (renderer != null)
@@ -27,7 +33,9 @@ namespace ReupVirtualTwin.managers
                 Material material = new Material(Shader.Find("Universal Render Pipeline/Lit"));
                 material.color = newColor;
                 renderer.material = material;
+                return true;
             }
+            return false;
         }
     }
 }

--- a/Runtime/ModelInterfaces/IObjectMetaDataGetterSetter.cs
+++ b/Runtime/ModelInterfaces/IObjectMetaDataGetterSetter.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+
+namespace ReupVirtualTwin.modelInterfaces
+{
+    public interface IObjectMetaDataGetterSetter
+    {
+        public JObject objectMetaData { get; set; }
+    }
+}

--- a/Runtime/ModelInterfaces/IObjectMetaDataGetterSetter.cs.meta
+++ b/Runtime/ModelInterfaces/IObjectMetaDataGetterSetter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4c455109fa829d4b9ec91e28cc7eb0b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Models/RegisteredIdentifier.cs
+++ b/Runtime/Models/RegisteredIdentifier.cs
@@ -1,11 +1,15 @@
 using ReupVirtualTwin.helpers;
 using UnityEngine;
 using ReupVirtualTwin.modelInterfaces;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 
 namespace ReupVirtualTwin.models
 {
-    public class RegisteredIdentifier : UniqueId
+    public class RegisteredIdentifier : UniqueId, IObjectMetaDataGetterSetter
     {
+        public JObject objectMetaData { get => _objectMetaData; set => _objectMetaData = value;}
+        private JObject _objectMetaData;
         public string manualId = "";
         IObjectRegistry _objectRegistry;
 

--- a/Tests/PlayMode/ChangeColorObjectsTest.cs
+++ b/Tests/PlayMode/ChangeColorObjectsTest.cs
@@ -2,26 +2,19 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.TestTools;
-using System.Linq;
-using System;
 using NUnit.Framework;
 
 using ReupVirtualTwin.models;
+using ReupVirtualTwin.managers;
+using ReupVirtualTwin.enums;
+using ReupVirtualTwin.managerInterfaces;
 using ReupVirtualTwin.modelInterfaces;
 using ReupVirtualTwin.helpers;
-using ReupVirtualTwin.managers;
-using ReupVirtualTwin.enums;
-using ReupVirtualTwin.managerInterfaces;
-using ReupVirtualTwin.managers;
-using ReupVirtualTwin.enums;
-using ReupVirtualTwin.managerInterfaces;
-using ReupVirtualTwin.models;
-using ReupVirtualTwin.modelInterfaces;
-using NUnit.Framework;
+using Newtonsoft.Json.Linq;
 
 public class ChangeColorObjectsTest : MonoBehaviour
 {
-    GameObject containerGameObject;
+    ReupSceneInstantiator.SceneObjects sceneObjects;
     ChangeColorManager changeColorManager;
     MockMediator mockMediator;
 
@@ -33,8 +26,8 @@ public class ChangeColorObjectsTest : MonoBehaviour
     [SetUp]
     public void SetUp()
     {
-        containerGameObject = new GameObject("containerGameObject");
-        changeColorManager = containerGameObject.AddComponent<ChangeColorManager>();
+        sceneObjects = ReupSceneInstantiator.InstantiateScene();
+        changeColorManager = sceneObjects.changeColorManager;
         mockMediator = new MockMediator();
         changeColorManager.mediator = mockMediator;
         CreateObjects();
@@ -42,20 +35,58 @@ public class ChangeColorObjectsTest : MonoBehaviour
     [TearDown]
     public void TearDown()
     {
-        Destroy(containerGameObject);
+        ReupSceneInstantiator.DestroySceneObjects(sceneObjects);
         Destroy(meshedParent);
         Destroy(unmeshedParent);
         Destroy(meshedChild);
         Destroy(unmeshedChild);
     }
+    private void CreateObjects()
+    {
+        meshedParent = new GameObject();
+        unmeshedParent = new GameObject();
+        unmeshedChild = new GameObject();
+        meshedChild = new GameObject();
+
+        meshedParent.AddComponent<RegisteredIdentifier>().GenerateId();
+        meshedParent.AddComponent<MeshRenderer>();
+
+        unmeshedParent.AddComponent<RegisteredIdentifier>().GenerateId();
+
+        unmeshedChild.AddComponent<RegisteredIdentifier>().GenerateId();
+        unmeshedChild.transform.parent = meshedParent.transform;
+
+        meshedChild.AddComponent<RegisteredIdentifier>().GenerateId();
+        meshedChild.AddComponent<MeshRenderer>();
+        meshedChild.transform.parent = unmeshedParent.transform;
+    }
+
     public List<string> GetIDsArray(List<GameObject> gameObjects)
     {
         List<string> stringIDs = new List<string>();
         foreach (GameObject obj in gameObjects)
         {
-            stringIDs.Add(obj.GetComponent<UniqueId>().getId());
+            stringIDs.Add(obj.GetComponent<IUniqueIdentifier>().getId());
         }
         return stringIDs;
+    }
+    private class MockMediator : IMediator
+    {
+        public bool deleteModeActive = false;
+        public bool notified = false;
+
+        public void Notify(ReupEvent eventName)
+        {
+            if (eventName == ReupEvent.objectsDeleted)
+            {
+                notified = true;
+            }
+        }
+
+        public void Notify<T>(ReupEvent eventName, T payload)
+        {
+            throw new System.NotImplementedException();
+        }
     }
 
     [UnityTest]
@@ -81,42 +112,57 @@ public class ChangeColorObjectsTest : MonoBehaviour
         yield return null;
     }
 
-    private class MockMediator : IMediator
+    [UnityTest]
+    public IEnumerator ShouldAddColorMetaDataToObjects()
     {
-        public bool deleteModeActive = false;
-        public bool notified = false;
+        List<GameObject> gameObjects = new() { meshedParent, meshedChild, unmeshedParent, unmeshedChild};
+        changeColorManager.ChangeObjectsColor(gameObjects, Color.blue);
+        yield return null;
 
-        public void Notify(ReupEvent eventName)
+        string blueColorRGBA = ColorUtility.ToHtmlStringRGBA(Color.blue);
+        AssertUtils.AssertAllObjectsWithMeshRendererHaveMetaDataValue<string>(
+            gameObjects,
+            "appearance.color",
+            blueColorRGBA);
+        yield return null;
+
+        changeColorManager.ChangeObjectsColor(gameObjects, Color.red);
+        yield return null;
+
+        string redColorRGBA = ColorUtility.ToHtmlStringRGBA(Color.red);
+        AssertUtils.AssertAllObjectsWithMeshRendererHaveMetaDataValue<string>(
+            gameObjects,
+            "appearance.color",
+            redColorRGBA);
+        yield return null;
+    }
+    void AssignFakeMaterialIdMetaDataToObjects(List<GameObject> objects, int materialId)
+    {
+        for (int i = 0; i < objects.Count; i++)
         {
-            if (eventName == ReupEvent.objectsDeleted)
+            if (objects[i].GetComponent<MeshRenderer>() != null)
             {
-                notified = true;
+                ObjectMetaDataUtils.AssignMaterialIdMetaDataToObject(objects[i], materialId);
             }
         }
-
-        public void Notify<T>(ReupEvent eventName, T payload)
-        {
-            throw new System.NotImplementedException();
-        }
     }
-
-    private void CreateObjects()
+    [UnityTest]
+    public IEnumerator ShouldDeleteMaterialIdMetaData_when_applyingColorMetaData()
     {
-        meshedParent = new GameObject();
-        unmeshedParent = new GameObject();
-        unmeshedChild = new GameObject();
-        meshedChild = new GameObject();
-
-        meshedParent.AddComponent<UniqueId>().GenerateId();
-        meshedParent.AddComponent<MeshRenderer>();
-
-        unmeshedParent.AddComponent<UniqueId>().GenerateId();
-
-        unmeshedChild.AddComponent<UniqueId>().GenerateId();
-        unmeshedChild.transform.parent = meshedParent.transform;
-
-        meshedChild.AddComponent<UniqueId>().GenerateId();
-        meshedChild.AddComponent<MeshRenderer>();
-        meshedChild.transform.parent = unmeshedParent.transform;
+        List<GameObject> gameObjects = new() { meshedParent, meshedChild, unmeshedParent, unmeshedChild};
+        int fakeMaterialId = 746;
+        AssignFakeMaterialIdMetaDataToObjects(gameObjects, fakeMaterialId);
+        AssertUtils.AssertAllObjectsWithMeshRendererHaveMetaDataValue<int>(gameObjects, "appearance.material_id", fakeMaterialId);
+        changeColorManager.ChangeObjectsColor(gameObjects, Color.blue);
+        yield return null;
+        List<JToken> objectsMaterialId = ObjectMetaDataUtils.GetMetaDataValuesFromObjects(
+            gameObjects, "appearance.material_id");
+        AssertUtils.AssertAllAreNull(objectsMaterialId);
+        AssertUtils.AssertAllObjectsWithMeshRendererHaveMetaDataValue<string>(
+            gameObjects,
+            "appearance.color",
+            ColorUtility.ToHtmlStringRGBA(Color.blue));
+        yield return null;
     }
+
 }

--- a/Tests/PlayMode/Mocks/MetaDataComponentMock.cs
+++ b/Tests/PlayMode/Mocks/MetaDataComponentMock.cs
@@ -1,0 +1,14 @@
+using Newtonsoft.Json.Linq;
+using ReupVirtualTwin.modelInterfaces;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Tests.PlayMode.Mocks
+{
+    class MetaDataComponentMock : MonoBehaviour, IObjectMetaDataGetterSetter
+    {
+        public JObject _objectMetaData;
+        public JObject objectMetaData { get => _objectMetaData; set => _objectMetaData = value; }
+    }
+}

--- a/Tests/PlayMode/Mocks/MetaDataComponentMock.cs.meta
+++ b/Tests/PlayMode/Mocks/MetaDataComponentMock.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 198218f39fc17424abf68ab46a2edb87
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/Mocks/SomeObjectWithMaterialRegistrySpy.cs
+++ b/Tests/PlayMode/Mocks/SomeObjectWithMaterialRegistrySpy.cs
@@ -15,6 +15,7 @@ namespace Tests.PlayMode.Mocks
             {
                 GameObject obj = new();
                 obj.AddComponent<UniqueId>().GenerateId();
+                obj.AddComponent<MetaDataComponentMock>();
                 if (i % 2 == 0)
                 {
                     obj.AddComponent<MeshRenderer>();
@@ -50,6 +51,14 @@ namespace Tests.PlayMode.Mocks
         public void RemoveObject(GameObject item)
         {
             throw new System.NotImplementedException();
+        }
+
+        public void DestroyAllObjects()
+        {
+            for(int i = 0; i < objects.Count; i++)
+            {
+                Object.Destroy(objects[i]);
+            }
         }
     }
 }

--- a/Tests/PlayMode/ModelInfoManagerTest.cs
+++ b/Tests/PlayMode/ModelInfoManagerTest.cs
@@ -1,22 +1,27 @@
 using System;
 using System.Collections;
-using NUnit.Framework;
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
 using ReupVirtualTwin.dataModels;
 using ReupVirtualTwin.controllers;
 using ReupVirtualTwin.helpers;
-using ReupVirtualTwin.managerInterfaces;
 using ReupVirtualTwin.managers;
 using ReupVirtualTwin.enums;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using ReupVirtualTwin.modelInterfaces;
+using Tests.PlayMode.Mocks;
 
 public class ModelInfoManagerTest : MonoBehaviour
 {
+    ObjectMapper objectMapper = new ObjectMapper(new TagsController(), new IdController());
     GameObject ModelInfoManagerPrefab = AssetDatabase.LoadAssetAtPath<GameObject>("Packages/com.reup.romulo/Assets/ScriptHolders/ModelInfoManager.prefab");
     GameObject ModelInfoManagerContainerGameObject;
     GameObject setupBuildingGameObject;
     GameObject buildingGameObject;
+    ModelInfoManager modelInfoManager;
     const int BUILDING_CHILDREN_DEPTH = 30;
 
 
@@ -25,6 +30,7 @@ public class ModelInfoManagerTest : MonoBehaviour
     {
         CreateStubSetupBuilding();
         ModelInfoManagerContainerGameObject = Instantiate(ModelInfoManagerPrefab);
+        modelInfoManager = ModelInfoManagerContainerGameObject.GetComponent<ModelInfoManager>();
         yield return null;
     }
     [UnityTearDown]
@@ -83,21 +89,45 @@ public class ModelInfoManagerTest : MonoBehaviour
         return true;
     }
 
+    bool IdStructureAreEqual(JObject expected, JObject obtained)
+    {
+        JObject expectedIdStructure = ExtractIdStructureOnly(expected);
+        JObject obtainedIdStructure = ExtractIdStructureOnly(obtained);
+        return JToken.DeepEquals(expectedIdStructure, obtainedIdStructure);
+    }
+
+    JObject ExtractIdStructureOnly(JObject obj)
+    {
+        List<JObject> extractedChildren = new List<JObject>();
+        JToken children = obj["children"];
+        if (children == null)
+        {
+            return new JObject(new JProperty("id", obj["id"]));
+        }
+        foreach (JObject child in children)
+        {
+            extractedChildren.Add(ExtractIdStructureOnly(child));
+        }
+        return new JObject(
+            new JProperty("id", obj["id"]),
+            new JProperty("children", new JArray(extractedChildren.ToArray())));
+    }
+
     [UnityTest]
     public IEnumerator ShouldObtainTheModelInfoMessage()
     {
-        WebMessage<ModelInfoMessage> message = ((ModelInfoManager)ModelInfoManagerContainerGameObject.GetComponent<IModelInfoManager>()).ObtainModelInfoMessage();
+        WebMessage<ModelInfoMessage> message = modelInfoManager.ObtainModelInfoMessage();
         Assert.IsNotNull(message);
         Assert.AreEqual(WebMessageType.requestModelInfoSuccess, message.type);
         Assert.IsNotNull(message.payload);
-        Assert.AreEqual(((ModelInfoManager)ModelInfoManagerContainerGameObject.GetComponent<IModelInfoManager>()).buildVersion, message.payload.buildVersion);
+        Assert.AreEqual(modelInfoManager.buildVersion, message.payload.buildVersion);
         yield return null;
     }
 
     [UnityTest]
     public IEnumerator ShouldObtainTheUpdateBuildingMessage()
     {
-        WebMessage<UpdateBuildingMessage> message = ((ModelInfoManager)ModelInfoManagerContainerGameObject.GetComponent<IModelInfoManager>()).ObtainUpdateBuildingMessage();
+        WebMessage<UpdateBuildingMessage> message = modelInfoManager.ObtainUpdateBuildingMessage();
         Assert.IsNotNull(message);
         Assert.AreEqual(WebMessageType.updateBuilding, message.type);
         Assert.IsNotNull(message.payload);
@@ -107,9 +137,8 @@ public class ModelInfoManagerTest : MonoBehaviour
     [UnityTest]
     public IEnumerator ShouldObtainBuildingTreeDataStructure()
     {
-        ObjectMapper objectMapper = new ObjectMapper(new TagsController(), new IdController());
         ObjectDTO expectedBuildingTreeDataStructure = objectMapper.MapObjectTree(buildingGameObject);
-        WebMessage<ModelInfoMessage> message = ((ModelInfoManager)ModelInfoManagerContainerGameObject.GetComponent<IModelInfoManager>()).ObtainModelInfoMessage();
+        WebMessage<ModelInfoMessage> message = modelInfoManager.ObtainModelInfoMessage();
         ObjectDTO buildingTreeDataStructure = message.payload.building;
         Assert.IsTrue(CompareObjectDTOs(expectedBuildingTreeDataStructure, buildingTreeDataStructure));
         Assert.AreEqual(NumberOfObjectsInTree(expectedBuildingTreeDataStructure), NumberOfObjectsInTree(buildingTreeDataStructure));
@@ -121,11 +150,60 @@ public class ModelInfoManagerTest : MonoBehaviour
     {
         int numberOfObjectsByDefaultInStubBuilding = 4;
         int numberOfObjectsInTotal = numberOfObjectsByDefaultInStubBuilding + BUILDING_CHILDREN_DEPTH;
-        WebMessage<ModelInfoMessage> message = ((ModelInfoManager)ModelInfoManagerContainerGameObject.GetComponent<IModelInfoManager>()).ObtainModelInfoMessage();
+        WebMessage<ModelInfoMessage> message = modelInfoManager.ObtainModelInfoMessage();
         ObjectDTO buildingTreeDataStructure = message.payload.building;
         Assert.AreEqual(numberOfObjectsInTotal, NumberOfObjectsInTree(buildingTreeDataStructure));
         yield return null;
     }
 
+    [UnityTest]
+    public IEnumerator ShouldGetSceneStateMessage_with_SameIdStructureAsBuilding()
+    {
+        JObject sceneSTate = modelInfoManager.GetSceneState();
+        ObjectDTO buildingTreeDataStructure = objectMapper.MapObjectTree(buildingGameObject);
+        Assert.IsTrue(IdStructureAreEqual(JObject.FromObject(buildingTreeDataStructure), sceneSTate));
+        yield return null;
+    }
+
+    [UnityTest]
+    public IEnumerator ShouldGetSceneStateMessage_with_noAppearanceInfoAtTheBeginning()
+    {
+        JObject sceneSTate = modelInfoManager.GetSceneState();
+        Assert.IsNull(sceneSTate["appearance"]);
+        Assert.IsNull(sceneSTate["children"][0]["appearance"]);
+        Assert.IsNull(sceneSTate["children"][1]["appearance"]);
+        yield return null;
+    }
+
+    [UnityTest]
+    public IEnumerator ShouldGetColorInfoInSceneStateMessage()
+    {
+        MetaDataComponentMock metaDataComponent = buildingGameObject.AddComponent<MetaDataComponentMock>();
+        JObject parentMetaData = new JObject
+        {
+            { "appearance", new JObject
+                {
+                    { "color", "test-color-parent" }
+                }
+            }
+        };
+        metaDataComponent.objectMetaData = parentMetaData;
+
+        MetaDataComponentMock metaDataChildComponent = buildingGameObject.transform.GetChild(0).gameObject.AddComponent<MetaDataComponentMock>();
+        JObject childMetaData = new JObject
+        {
+            { "appearance", new JObject
+                {
+                    { "color", "test-color-child" }
+                }
+            }
+        };
+        metaDataChildComponent.objectMetaData = childMetaData;
+
+        JObject sceneSTate = modelInfoManager.GetSceneState();
+        Assert.AreEqual(parentMetaData["appearance"]["color"], sceneSTate["appearance"]["color"]);
+        Assert.AreEqual(childMetaData["appearance"]["color"], sceneSTate["children"][0]["appearance"]["color"]);
+        yield return null;
+    }
 
 }

--- a/Tests/PlayMode/ObjectMapperTest.cs
+++ b/Tests/PlayMode/ObjectMapperTest.cs
@@ -12,17 +12,25 @@ using ReupVirtualTwin.controllers;
 public class ObjectMapperTest : MonoBehaviour
 {
     IObjectMapper objectMapper;
+    GameObject mockBuilding;
 
     [SetUp]
     public void SetUp()
     {
         objectMapper = new ObjectMapper(new TagsController(), new IdController());
+        mockBuilding = StubObjectTreeCreator.CreateMockBuilding();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Destroy(mockBuilding);
     }
 
     [UnityTest]
     public IEnumerator ShouldMapOneObject()
     {
-        ObjectDTO objectDTO = objectMapper.MapObjectToDTO(StubObjectTreeCreator.CreateMockBuilding());
+        ObjectDTO objectDTO = objectMapper.MapObjectToDTO(mockBuilding);
         Assert.AreEqual(StubObjectTreeCreator.parentId, objectDTO.id);
         Assert.AreEqual(StubObjectTreeCreator.parentTags, objectDTO.tags);
         Assert.IsNull(objectDTO.children);
@@ -31,10 +39,9 @@ public class ObjectMapperTest : MonoBehaviour
     [UnityTest]
     public IEnumerator ShouldMapSeveralObject()
     {
-        GameObject parent = StubObjectTreeCreator.CreateMockBuilding();
         ObjectDTO[] objectDTOs = objectMapper.MapObjectsToDTO(new GameObject[]
         {
-            parent, parent.transform.GetChild(0).gameObject, parent.transform.GetChild(1).gameObject
+            mockBuilding, mockBuilding.transform.GetChild(0).gameObject, mockBuilding.transform.GetChild(1).gameObject
         }.ToList());
         Assert.AreEqual(3, objectDTOs.Length);
         Assert.AreEqual(StubObjectTreeCreator.parentId, objectDTOs[0].id);
@@ -49,8 +56,7 @@ public class ObjectMapperTest : MonoBehaviour
     [UnityTest]
     public IEnumerator ShouldMapObjectTree()
     {
-        GameObject mockbuilding = StubObjectTreeCreator.CreateMockBuilding();
-        ObjectDTO treeDTO = objectMapper.MapObjectTree(mockbuilding);
+        ObjectDTO treeDTO = objectMapper.MapObjectTree(mockBuilding);
         Assert.AreEqual(StubObjectTreeCreator.parentId, treeDTO.id);
         Assert.AreEqual(StubObjectTreeCreator.parentTags, treeDTO.tags);
         Assert.AreEqual(StubObjectTreeCreator.child0Tags, treeDTO.children[0].tags);

--- a/Tests/PlayMode/ObjectTagsTest.cs
+++ b/Tests/PlayMode/ObjectTagsTest.cs
@@ -4,7 +4,6 @@ using UnityEngine.TestTools;
 using NUnit.Framework;
 
 using ReupVirtualTwin.models;
-using ReupVirtualTwin.enums;
 using ReupVirtualTwin.dataModels;
 
 

--- a/Tests/PlayMode/Utils/AssertUtils.cs
+++ b/Tests/PlayMode/Utils/AssertUtils.cs
@@ -1,0 +1,35 @@
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using ReupVirtualTwin.helpers;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class AssertUtils
+{
+
+    public static void AssertAllObjectsWithMeshRendererHaveMetaDataValue<T>(List<GameObject> objects, string metaDataPath, object metaDataValue)
+    {
+        List<JToken> metaDataValues = ObjectMetaDataUtils.GetMetaDataValuesFromObjects(objects, metaDataPath);
+        for (int i = 0; i < objects.Count; i++)
+        {
+            if (objects[i].GetComponent<MeshRenderer>() != null)
+            {
+                Assert.AreEqual(metaDataValue, metaDataValues[i].ToObject<T>());
+            }
+            else
+            {
+                Assert.IsNull(metaDataValues[i]);
+            }
+        }
+    }
+
+    public static void AssertAllAreNull<T>(List<T> list)
+    {
+        for (int i = 0; i < list.Count; i++)
+        {
+            Assert.IsNull(list[i]);
+        }
+    }
+
+}

--- a/Tests/PlayMode/Utils/AssertUtils.cs.meta
+++ b/Tests/PlayMode/Utils/AssertUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bbd5a394b4b930f4dae4519e995ef36f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/Utils/ReupSceneInstantiator.cs
+++ b/Tests/PlayMode/Utils/ReupSceneInstantiator.cs
@@ -1,7 +1,6 @@
 using ReupVirtualTwin.behaviourInterfaces;
+using ReupVirtualTwin.managers;
 using ReupVirtualTwin.models;
-using System.Collections;
-using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 
@@ -14,6 +13,7 @@ public static class ReupSceneInstantiator
         public GameObject character;
         public GameObject baseGlobalScriptGameObject;
         public GameObject building;
+        public ChangeColorManager changeColorManager;
     }
 
     public static SceneObjects InstantiateScene()
@@ -27,12 +27,18 @@ public static class ReupSceneInstantiator
         IBuildingGetterSetter setupBuilding = baseGlobalScriptGameObject.transform.Find("SetupBuilding").GetComponent<IBuildingGetterSetter>();
         setupBuilding.building = building;
 
+        ChangeColorManager changeColorManager = baseGlobalScriptGameObject.transform
+            .Find("EditionMediator")
+            .Find("ChangeColorManager")
+            .GetComponent<ChangeColorManager>();
+
         return new SceneObjects
         {
             reupObject = reupGameObject,
             character = character,
             baseGlobalScriptGameObject = baseGlobalScriptGameObject,
             building = building,
+            changeColorManager = changeColorManager,
         };
     }
 


### PR DESCRIPTION
* Update prefab name

* Update mediator

* Create Reup prefab test file

* modify the setup and the teardown methods to of the IdControllerTest to make sure that the objectRegistryGameObject is created and erased before and after each test.

* Modifies the setup and teardown methods of the IdControllerTest, ObjectRegistryTest and RegisteredIdentifierTest.

Ensures that the objectRegistryGameObject is created and deleted before and after each test, taking care of asynchronous  operations.

* Fix set up building

* Fix minor details

* Move IRegistry from models folder to modelsInterface Folder.

Also, updates the dependency injector assembly to include the modelsInterface assembly, ensuring that the IRegistry interface can be used without problems.

* Update all code dependent on IRegistry interface

* Change the input movement keys

The user can walk straight with the up and down arrow keys. The user can rotate the view with the left and right arrow keys. The user can walk straight and sideways with the WASD keys. No other movement keys are affected.

* tags url now lives in ObjectTags script, not in editor script

* Update Runtime/Managers/ChangeColorManager.cs

* Add the UnityTearDown method to enable yielding during objectRegistry destruction in teardown phase

* Change to new material with color

* Fix initial objects position inside reup prefab

* Put mocks before tests

* Create ChangeMaterialController

* Fix version

* Move TagsWebRequesterControlle

* Move TagsApiConsumer to web requester folder

* Address commments

* Create TExtureDownloader

* Move RegistrySpy

* Rename IobjectRegistry

* Change materials of objects

* Create assign texture test

* Comments addressed

* Comments addressed

* Test to apply downloaded material

* Implement Texture Downloader

* Delegate change material from mediator to controller

* Make test classes private in InsertObjectControllerTest

* Rename variables

* Notify mediator when object materials change

* Send message when material are changed

* Fix minnor prefab error

* Remove unnused property

* Remove old code

* Fix movement input keys

* Fix multiple tag fetch

* Change action tags

* Create test workflow

* modify move to tmp folder step

* not checking out folders

* remove sparse-checkout

* Deleting most of the code

* rename main.yml

* remove comments

* publish results

* end list and failing test

* publish test in comment

* remove coverage logic

* remove failing test

* define which .xml files to publish

* Revert "Deleting most of the code"

This reverts commit fa8c1ac0f73cf87719fc290fb013b8982acdecf0.

* remove webgl ifs

* remove UNITY_WEBGL if

* Add unity mesh simplifier dependency

* Revert "Add unity mesh simplifier dependency"

This reverts commit 88cade816b56e29169fd9c487c8c82ce496a6934.

* Add UnityMeshSimplifer code to package

* rename test.yml

* remove unnecessary lines

* move behaviour interfaces to right folder

* Move Utils to helpers folders

* restaurate SimplifyMesh

* Change the startupMessage for the 3 way handshake comunication

* Adjustments

* Adjustments

* Adjustments

* Adjustements

* Tests for the ModelInfoManager

* update IObjectRegistry name

* return material url as part of response

* Handle error when error happens when attempt to downlaod texture fails

* Automate Unity builds using a C# script

* Update Runtime/Helpers/Utils.cs



* Save Tag objects instead of just tag names

* Set all positions to 0 in Reup prefab

* update package version

* Comments addressed

* rename actions that send object data to angular

* Create data manipulation helpers

* Remove test workflows

* Add array support

* return types of values

* Make new payload format work

* Just remove publish step

This reverts commit 23bc14ec0626c443ae1514c516dafb7d57c6005a.

* not working because fighting JObject

* Use JObject in Change material controller

* Make Edition Mediator use JObject

* Clean

* Add Validation to Incoming messages

* Receive boolean when setting edit mode

* expect JObject as notification payload when material change

* use same syntax for schemas

* send change color success message

* Create TagFinderTool script

* Create SelectTagsSection

* Create first tag filter

* Create filter applier

* Rename TagScannerTool

* Apply filters

* Fix trying to use selectTagSection before created

* Fix tags api manager failing when server is down

* One Test is failing

* let filters scan the whole object tree

* increase tests

* Fix including objects that are inside non desired objects

* Implement Misapply filters buttons

* Test Subsdtring tag filter

* Fix filters not populating when reload

* Clean debugs

* Clean names

* fix auto builder

* Create First version of Validator

* Validate nested objects

* implement structured schemas

* Add warning log with key name

* Add Validation to JValues

* Validate objects against other types

* something

* Create IncomingMessageValidator

* Register incoming messages

* Clean

* Update building

* Staging (#123)

* fixing delete manager to delete based on id

* changing method name, avoiding returning null

* Fix camera selecting character intead of material picker

* apply fix to extension triggers

* Improve DummpyJsonCreator

* feat: select object after insertion

BREAKING CHANGE: changed the payload sent to unity to insert furniture from an string (the fbx url) to an object with the interface `{objectUrl: string, selectObjectAfterInsertion: boolean, deselectPreviousSelection: boolean}`

* Pass object id to insert object manager

* commit

* Add change color dependency injector

* Drop the paintable tag and update to receive a list of objects ids to paint, alongside the RGB color to apply

* changing color on children objects with tests

* Modified change color manager and tests

* Assign new id to inserted object

* Delete 's'

* Add missing tests

* Fix identifier typo

* Update Runtime/Enums/ObjectTag.cs

Delete paintable tag



* Use string instead of enum as tags

* Changed ReupEvent to objectColorChanged

* Refactor to ChangeObjectsColor

* Delete tags controller and unused libraries

* Create custom ObjectTag Editor

* ObjectRegistry update

* Utils update

* Tests updated

* Check when user reach bottom of tags

* Create Tags Api Manager

* Fetching Tags

* Rename EditionTag

* use strings instead of tags enum

* Clean up

* Remove FinderController

* Clean code

* Create InsertObjectController

* First test of InsertObjectController

* Implement InsertObjectController in EditionMediator

* Send InsertedObjectPayload to mediator

* Add Test for Tags in inserted object

* Fix Edition Mediator to use new Insert Object Controller

* Add colliders to inserted object

* Add simultanious insertion tests

* Clean and remove unnused code

* Fix comments

* Delete the MonoBehaviour inheritance from the CharacterColliderBoxController

Also update the DestroyCollider() method as it was using the Destroy() method from the MonoBehaviourr inheritance.

* Create StubOnSetupBuildingCreator

* Create IBuilddingGetter interface

* Get SendStartupMessage with tests

* Fix web message sender not ready yet

* REUP-241 Make drop down menu smaller

* Test fixed

* Update prefab name

* Update mediator

* Create Reup prefab test file

* modify the setup and the teardown methods to of the IdControllerTest to make sure that the objectRegistryGameObject is created and erased before and after each test.

* Modifies the setup and teardown methods of the IdControllerTest, ObjectRegistryTest and RegisteredIdentifierTest.

Ensures that the objectRegistryGameObject is created and deleted before and after each test, taking care of asynchronous  operations.

* Fix set up building

* Fix minor details

* Move IRegistry from models folder to modelsInterface Folder.

Also, updates the dependency injector assembly to include the modelsInterface assembly, ensuring that the IRegistry interface can be used without problems.

* Update all code dependent on IRegistry interface

* Change the input movement keys

The user can walk straight with the up and down arrow keys. The user can rotate the view with the left and right arrow keys. The user can walk straight and sideways with the WASD keys. No other movement keys are affected.

* tags url now lives in ObjectTags script, not in editor script

* Update Runtime/Managers/ChangeColorManager.cs

* Add the UnityTearDown method to enable yielding during objectRegistry destruction in teardown phase

* Change to new material with color

* Fix initial objects position inside reup prefab

* Put mocks before tests

* Create ChangeMaterialController

* Fix version

* Move TagsWebRequesterControlle

* Move TagsApiConsumer to web requester folder

* Address commments

* Create TExtureDownloader

* Move RegistrySpy

* Rename IobjectRegistry

* Change materials of objects

* Create assign texture test

* Comments addressed

* Comments addressed

* Test to apply downloaded material

* Implement Texture Downloader

* Delegate change material from mediator to controller

* Make test classes private in InsertObjectControllerTest

* Rename variables

* Notify mediator when object materials change

* Send message when material are changed

* Fix minnor prefab error

* Remove unnused property

* Remove old code

* Fix movement input keys

* Fix multiple tag fetch

* Change action tags

* Create test workflow

* modify move to tmp folder step

* not checking out folders

* remove sparse-checkout

* Deleting most of the code

* rename main.yml

* remove comments

* publish results

* end list and failing test

* publish test in comment

* remove coverage logic

* remove failing test

* define which .xml files to publish

* Revert "Deleting most of the code"

This reverts commit fa8c1ac0f73cf87719fc290fb013b8982acdecf0.

* remove webgl ifs

* remove UNITY_WEBGL if

* Add unity mesh simplifier dependency

* Revert "Add unity mesh simplifier dependency"

This reverts commit 88cade816b56e29169fd9c487c8c82ce496a6934.

* Add UnityMeshSimplifer code to package

* rename test.yml

* remove unnecessary lines

* move behaviour interfaces to right folder

* Move Utils to helpers folders

* restaurate SimplifyMesh

* Change the startupMessage for the 3 way handshake comunication

* Adjustments

* Adjustments

* Adjustments

* Adjustements

* Tests for the ModelInfoManager

* update IObjectRegistry name

* return material url as part of response

* Handle error when error happens when attempt to downlaod texture fails

* Automate Unity builds using a C# script

* Update Runtime/Helpers/Utils.cs



* Save Tag objects instead of just tag names

* Set all positions to 0 in Reup prefab

* update package version

* Comments addressed

* rename actions that send object data to angular

* Create data manipulation helpers

* Remove test workflows

* Add array support

* return types of values

* Make new payload format work

* Just remove publish step

This reverts commit 23bc14ec0626c443ae1514c516dafb7d57c6005a.

* not working because fighting JObject

* Use JObject in Change material controller

* Make Edition Mediator use JObject

* Clean

* Add Validation to Incoming messages

* Receive boolean when setting edit mode

* expect JObject as notification payload when material change

* use same syntax for schemas

* send change color success message

* fix auto builder

* Create First version of Validator

* Validate nested objects

* implement structured schemas

* Add warning log with key name

* Add Validation to JValues

* Validate objects against other types

* something

* Create IncomingMessageValidator

* Register incoming messages

* Clean

---------






* new Version (#124)



* add permissions

* publish tests results

* only run test

* Update Building data model

* Comments addressed

* Fix indentation

* Change versiont from 1.1.2 to 1.1.3

* Address comments

* Address comments

* move insertion object

* Rename PointSensor

* Create Object Sensor

* Add test of dependency injections and highlight one object

* Hightlight same object only once

* unhighlight object

* Test object selector is for selectable objects

* Add switch to sensedobjectHighlighter

* make object sensor not a monobehaviour

* create test to enable highlight selectable objects only in edit mode

* do not highlight selected objects

* Create ReupPrefabInstantiator for test purposes

* Apply ReupPrefabInstantiator in Maintain height tests

* rename ReupSceneInstantiator

* create metada in registered identifier

* Save color metadata when changing object color

* object mapper maps metadata

* Move helper functions

* Fix identation

* create GetSceneState method

* create scene state message implementation

* Assign Material id MetaData

* update build version

* request material id in message

* receive and reply with scene name

* Add support for required fields in DataValidation

* add required fields to External schema

* Add required fields to internal schema

* Validate internal schemas

* Support schema references

* Fix internal schemas

* make generic meta data utils

* Deselect objects when sending scene state

* change border colors

* clean code

* change back api url

* Fix

* Update Version

* change tag data model

---------