### PR TITLE
Reup 331- Deselect all items

### DIFF
--- a/Runtime/Enums/WebMessageType.cs
+++ b/Runtime/Enums/WebMessageType.cs
@@ -9,6 +9,7 @@ namespace ReupVirtualTwin.enums
         public const string setEditModeSuccess = "[Edit Mode] Set Edit Mode Success";
 
         public const string setSelectedObjects = "[Selected Objects] Set Selected Objects Success v2";
+        public const string clearSelectedObjects = "[Selected Objects] Clear Selected Objects";
 
         public const string activatePositionTransform = "[Transform Objects] Activate Position Transform Mode";
         public const string activatePositionTransformSuccess = "[Transform Objects] Activate Position Transform Mode Success";

--- a/Runtime/Managers/EditionMediator.cs
+++ b/Runtime/Managers/EditionMediator.cs
@@ -75,6 +75,7 @@ namespace ReupVirtualTwin.managers
             incomingMessageValidator.RegisterMessage(WebMessageType.activateRotationTransform);
             incomingMessageValidator.RegisterMessage(WebMessageType.deactivateTransformMode);
             incomingMessageValidator.RegisterMessage(WebMessageType.requestModelInfo);
+            incomingMessageValidator.RegisterMessage(WebMessageType.clearSelectedObjects);
 
             incomingMessageValidator.RegisterMessage(WebMessageType.setEditMode, DataValidator.boolSchema);
 
@@ -220,6 +221,9 @@ namespace ReupVirtualTwin.managers
                     break;
                 case WebMessageType.requestSceneLoad:
                     await LoadObjectsState((JObject)payload);
+                    break;
+                case WebMessageType.clearSelectedObjects:
+                    _selectedObjectsManager.ClearSelection();
                     break;
             }
         }

--- a/Tests/PlayMode/EditionMediatorTest.cs
+++ b/Tests/PlayMode/EditionMediatorTest.cs
@@ -834,6 +834,16 @@ public class EditionMediatorTest : MonoBehaviour
         Assert.AreEqual(1, mockWebMessageSender.sentMessages.Count);
     }
 
+    [UnityTest]
+    public IEnumerator ShouldClearSelectedObjects()
+    {
+        Assert.AreEqual(mockSelectedObjectsManager.selectionCleared, false);
+        string message = JObject.FromObject(new { type = WebMessageType.clearSelectedObjects }).ToString();
+        editionMediator.ReceiveWebMessage(message);
+        yield return null;
+        Assert.AreEqual(mockSelectedObjectsManager.selectionCleared, true);
+    }
+
     [Test]
     public async Task ShouldRequestChangeObjectsMaterial_when_Receive_loadSceneRequest_with_onlyOneMaterial()
     {


### PR DESCRIPTION
[REUP-331](https://macheight-reup.atlassian.net/browse/REUP-331)

As a user, I would like a way to deselect all objects in the scene so that I can easily clear my selection

AC:

Clicking the “x” icon on the left of the “selected objects” menu clears all selected objects

[ReUp - User experience refresh](https://www.figma.com/design/KEjCbjCwJrXI50AfSMy4cc/ReUp---User-experience-refresh?node-id=179-12661&t=04nmEEpP4qWndqym-4) 

The app returns to the screen with edit mode open and no objects selected

https://www.figma.com/design/KEjCbjCwJrXI50AfSMy4cc/ReUp---User-experience-refresh?node-id=179-10286&t=04nmEEpP4qWndqym-4