### PR TITLE
return all objects with that passed inverted filters

### DIFF
--- a/Runtime/Helpers/TagFilterUtils.cs
+++ b/Runtime/Helpers/TagFilterUtils.cs
@@ -31,7 +31,6 @@ namespace ReupVirtualTwin.helpers
                 bool allChildrenPassed = children.All(child => filteredObjects.Contains(child)); 
                 if (allChildrenPassed)
                 {
-                    filteredObjects.Clear();
                     filteredObjects.Add(treeHead);
                 }
             }

--- a/Tests/PlayMode/TagFiltersApplierTest.cs
+++ b/Tests/PlayMode/TagFiltersApplierTest.cs
@@ -175,5 +175,18 @@ namespace ReupVirtualTwinTests.controllers
             Assert.IsTrue(filteredObjects.Contains(building.transform.GetChild(0).GetChild(1).gameObject));
         }
 
+        [Test]
+        public void ShouldReturnObjects_WithTagZ_And_WithoutNotPresentTag()
+        {
+            building = StubObjectTreeWithTagAtDifferentLevelsCreator.CreateMockObjectWithArbitraryTagAtSecondAndThirdLevel();
+            ITagFilter filterZ = new TagFilter(StubObjectTreeWithTagAtDifferentLevelsCreator.tagZ);
+            ITagFilter filterNotPresentTag = new TagFilter(StubObjectTreeWithTagAtDifferentLevelsCreator.notPesentTag);
+            filterNotPresentTag.invertFilter = true;
+            List<ITagFilter> filterList = new List<ITagFilter>() {filterZ, filterNotPresentTag};
+            List<GameObject> filteredObjects = TagFiltersApplier.ApplyFiltersToTree(building, filterList);
+            Assert.AreEqual(1, filteredObjects.Count);
+            Assert.IsTrue(filteredObjects.Contains(building.transform.GetChild(0).gameObject));
+        }
+
     }
 }

--- a/Tests/PlayMode/Utils/StubObjectTreeWithTagAtDifferentLevelsCreator.cs
+++ b/Tests/PlayMode/Utils/StubObjectTreeWithTagAtDifferentLevelsCreator.cs
@@ -13,6 +13,7 @@ public class StubObjectTreeWithTagAtDifferentLevelsCreator
     public static Tag tagX = new Tag() { id = "tag-x", name = "tag X" };
     public static Tag tagY = new Tag() { id = "tag-y", name = "tag Y" };
     public static Tag tagZ = new Tag() { id = "tag-z", name = "tag Z" };
+    public static Tag notPesentTag = new Tag() { id = "notPesentTag-id", name = "notPesentTag" };
 
     /// <summary>
     /// Creates a mock object tree with an object with the following structure:


### PR DESCRIPTION
[Reup347](https://macheight-reup.atlassian.net/browse/REUP-347?atlOrigin=eyJpIjoiNjk5NWI5MmNmNTIyNDg3YjgxMTQ3MDY4MjM5MGM0NmIiLCJwIjoiaiJ9)

As a developer, I want to fix the tag scanner, so the designer can use it in real models

AC:

In the following scenario: cube(1) has tagA and tagB, cube(2) has only tagB. If the tag scanner is set to show all objects with tagB but NOT tagA, only the game object cube(2) should be visible (currently none is visible)