### PR TITLE
Reup357 update trilib used api

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,6 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
           packageMode: true
-          unityVersion: '2022.3.28f1'
+          unityVersion: '2022.3.15f1'
           projectPath: temporal_repo_folder
           artifactsPath: 'artifacts'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,6 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
           packageMode: true
-          unityVersion: '2021.3.24f1'
+          unityVersion: '2022.3.28f1'
           projectPath: temporal_repo_folder
           artifactsPath: 'artifacts'

--- a/Runtime/TriLib/TriLibCore/Scripts/AssetLoaders/AssetDownloader.cs
+++ b/Runtime/TriLib/TriLibCore/Scripts/AssetLoaders/AssetDownloader.cs
@@ -37,7 +37,7 @@ namespace TriLibCore
 #if UNITY_2023_1_OR_NEWER
                     unityWebRequest = UnityWebRequest.PostWwwForm(uri, data); 
 #else
-                    unityWebRequest = UnityWebRequest.Post(uri, data);
+                    unityWebRequest = UnityWebRequest.PostWwwForm(uri, data);
 #endif
                     break;
                 case HttpRequestMethod.Put:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "com.unity.inputsystem": "1.5.1",
     "com.unity.render-pipelines.universal": "12.1.11",
     "com.unity.textmeshpro": "3.0.6",
+    "com.unity.visualscripting": "1.9.4",
     "com.unity.test-framework": "2.0.1-exp.1"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "com.unity.inputsystem": "1.5.1",
     "com.unity.render-pipelines.universal": "12.1.11",
+    "com.unity.textmeshpro": "3.0.6",
     "com.unity.test-framework": "2.0.1-exp.1"
   },
   "keywords": [],


### PR DESCRIPTION
[Reup357](https://macheight-reup.atlassian.net/browse/REUP-357?atlOrigin=eyJpIjoiOGMyNDQ5MTI0MWZhNDE1MmFhNzk1OTc0MjkzZjhlNGEiLCJwIjoiaiJ9)

As a developer I want to update the trilib assets to the last API unity version 2022.3.**, so the developer team can work in this new version without the files updating automatically.

AC:

When a developer installs the package in a project with unity version 2022.3.**, unity does not prompt to update the trilib scripts to the new API version.

inserting objects from the catalog still works