### PR TITLE
Reup344 halo on hover

### DIFF
--- a/Assets/Materials/dummyEmissionMaterial.mat
+++ b/Assets/Materials/dummyEmissionMaterial.mat
@@ -1,0 +1,134 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-8056025173964060930
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: dummyEmissionMaterial
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _EMISSION
+  m_InvalidKeywords: []
+  m_LightmapFlags: 2
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 766.9961, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Materials/dummyEmissionMaterial.mat.meta
+++ b/Assets/Materials/dummyEmissionMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0326bc1feb064a249895274fbbabf7ee
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Quickstart/Reup.prefab
+++ b/Assets/Quickstart/Reup.prefab
@@ -23,6 +23,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2800249913291930678}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -31,88 +32,109 @@ Transform:
   - {fileID: 1191157721440923679}
   - {fileID: 680367125633172352}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1940689160094875461
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 1178337683573207492}
     m_Modifications:
-    - target: {fileID: 151350736762601885, guid: 6f1f1c16a02f5034d9fe1338ca73a63d, type: 3}
+    - target: {fileID: 151350736762601885, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
       propertyPath: m_Name
       value: Character
       objectReference: {fileID: 0}
-    - target: {fileID: 550144965969967984, guid: 6f1f1c16a02f5034d9fe1338ca73a63d, type: 3}
+    - target: {fileID: 550144965969967984, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
       propertyPath: initialCharacterHeight
       value: 1.75
       objectReference: {fileID: 0}
-    - target: {fileID: 589564064158956272, guid: 6f1f1c16a02f5034d9fe1338ca73a63d, type: 3}
+    - target: {fileID: 589564064158956272, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
       propertyPath: editModeManager
       value: 
       objectReference: {fileID: 5733580648411075496}
-    - target: {fileID: 589564064158956272, guid: 6f1f1c16a02f5034d9fe1338ca73a63d, type: 3}
+    - target: {fileID: 589564064158956272, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
       propertyPath: selectedObjectsManager
       value: 
       objectReference: {fileID: 9138131387677620797}
-    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d, type: 3}
+    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d, type: 3}
+    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d, type: 3}
+    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d, type: 3}
+    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d, type: 3}
+    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d, type: 3}
+    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d, type: 3}
+    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d, type: 3}
+    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d, type: 3}
+    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d, type: 3}
+    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d, type: 3}
+    - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1281623039952056728, guid: 6f1f1c16a02f5034d9fe1338ca73a63d, type: 3}
+    - target: {fileID: 1281623039952056728, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
       propertyPath: ignoreLayerMask.m_Bits
       value: 128
       objectReference: {fileID: 0}
-    - target: {fileID: 2523302795143341905, guid: 6f1f1c16a02f5034d9fe1338ca73a63d, type: 3}
+    - target: {fileID: 2523302795143341905, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
       propertyPath: _building
       value: 
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6f1f1c16a02f5034d9fe1338ca73a63d, type: 3}
 --- !u!4 &1191157721440923679 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d, type: 3}
+  m_CorrespondingSourceObject: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+    type: 3}
   m_PrefabInstance: {fileID: 1940689160094875461}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6737159228072708804
@@ -120,198 +142,249 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 1178337683573207492}
     m_Modifications:
-    - target: {fileID: 366445227718908430, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 366445227718908430, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: jumpPoints.Array.size
       value: 4
       objectReference: {fileID: 0}
-    - target: {fileID: 3742521412799980478, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 3742521412799980478, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3742521412799980478, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 3742521412799980478, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3742521412799980478, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 3742521412799980478, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3742521412799980478, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 3742521412799980478, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3742521412799980478, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 3742521412799980478, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3742521412799980478, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 3742521412799980478, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4234862582771738851, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 4234862582771738851, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5009605726572339642, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 5009605726572339642, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5009605726572339642, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 5009605726572339642, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5009605726572339642, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 5009605726572339642, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6056801452590680250, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 6056801452590680250, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_Name
       value: BaseGlobalScripts
       objectReference: {fileID: 0}
-    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6345926089304755210, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 6345926089304755210, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6345926089304755210, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 6345926089304755210, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6345926089304755210, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 6345926089304755210, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6345926089304755210, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 6345926089304755210, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6345926089304755210, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 6345926089304755210, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6345926089304755210, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 6345926089304755210, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7297208520348448944, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 7297208520348448944, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7297208520348448944, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 7297208520348448944, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7297208520348448944, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 7297208520348448944, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7297208520348448944, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 7297208520348448944, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7297208520348448944, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 7297208520348448944, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7297208520348448944, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 7297208520348448944, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8577674977601168461, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 8577674977601168461, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8577674977601168461, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 8577674977601168461, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8577674977601168461, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 8577674977601168461, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8577674977601168461, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 8577674977601168461, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8577674977601168461, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 8577674977601168461, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8577674977601168461, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 8577674977601168461, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8697303064361526626, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 8697303064361526626, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8697303064361526626, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 8697303064361526626, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8697303064361526626, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 8697303064361526626, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8697303064361526626, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+    - target: {fileID: 8697303064361526626, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
 --- !u!4 &680367125633172352 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+  m_CorrespondingSourceObject: {fileID: 6056801452590680388, guid: 0a661a8d20f9d7049b04205d674fffa8,
+    type: 3}
   m_PrefabInstance: {fileID: 6737159228072708804}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &5733580648411075496 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1364300036843526508, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+  m_CorrespondingSourceObject: {fileID: 1364300036843526508, guid: 0a661a8d20f9d7049b04205d674fffa8,
+    type: 3}
   m_PrefabInstance: {fileID: 6737159228072708804}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
@@ -322,7 +395,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
 --- !u!114 &9138131387677620797 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2571019425538633977, guid: 0a661a8d20f9d7049b04205d674fffa8, type: 3}
+  m_CorrespondingSourceObject: {fileID: 2571019425538633977, guid: 0a661a8d20f9d7049b04205d674fffa8,
+    type: 3}
   m_PrefabInstance: {fileID: 6737159228072708804}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}

--- a/Assets/Quickstart/Reup.prefab
+++ b/Assets/Quickstart/Reup.prefab
@@ -1,5 +1,110 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1259473726147856764
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3377086067190760999}
+  - component: {fileID: 8613542410132337739}
+  - component: {fileID: 4441016379326198771}
+  - component: {fileID: 3441289676134318693}
+  m_Layer: 0
+  m_Name: dummyEmissionObject_necessaryToHaveEmissionMaterials
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &3377086067190760999
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259473726147856764}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.44, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1178337683573207492}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8613542410132337739
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259473726147856764}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4441016379326198771
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259473726147856764}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 0326bc1feb064a249895274fbbabf7ee, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &3441289676134318693
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259473726147856764}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &2800249913291930678
 GameObject:
   m_ObjectHideFlags: 0
@@ -31,6 +136,7 @@ Transform:
   m_Children:
   - {fileID: 1191157721440923679}
   - {fileID: 680367125633172352}
+  - {fileID: 3377086067190760999}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1940689160094875461
@@ -84,22 +190,22 @@ PrefabInstance:
     - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.70710677
       objectReference: {fileID: 0}
     - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
         type: 3}
@@ -109,7 +215,7 @@ PrefabInstance:
     - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 750237606206558042, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
         type: 3}
@@ -125,6 +231,26 @@ PrefabInstance:
         type: 3}
       propertyPath: _building
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8348441568477808737, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
+      propertyPath: m_BackGroundColor.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8348441568477808737, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
+      propertyPath: m_BackGroundColor.b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8348441568477808737, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
+      propertyPath: m_BackGroundColor.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8348441568477808737, guid: 6f1f1c16a02f5034d9fe1338ca73a63d,
+        type: 3}
+      propertyPath: m_BackGroundColor.r
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -352,8 +478,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8697303064361526626, guid: 0a661a8d20f9d7049b04205d674fffa8,
         type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 8697303064361526626, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.77
+      objectReference: {fileID: 0}
+    - target: {fileID: 8697303064361526626, guid: 0a661a8d20f9d7049b04205d674fffa8,
+        type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1
+      value: 1.22
       objectReference: {fileID: 0}
     - target: {fileID: 8697303064361526626, guid: 0a661a8d20f9d7049b04205d674fffa8,
         type: 3}

--- a/Assets/ScriptHolders/Character.prefab
+++ b/Assets/ScriptHolders/Character.prefab
@@ -27,13 +27,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 203620772}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8380427711663556094}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &203620776
 MonoBehaviour:
@@ -111,13 +111,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1625360268}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4787269145028247440}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1625360271
 MonoBehaviour:
@@ -170,13 +170,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 16043791835660354}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.15, y: 0, z: 0}
   m_LocalScale: {x: 0.10328332, y: 0.10328332, z: 0.10328332}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8424176746612216539}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2154033466337776278
 MonoBehaviour:
@@ -216,13 +216,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 59472179402601666}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.15, y: 0, z: 0}
   m_LocalScale: {x: 0.10328332, y: 0.10328332, z: 0.10328332}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8424176746612216539}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &9145431129484315031
 MonoBehaviour:
@@ -266,13 +266,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 135168503502123684}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8380427711663556094}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &8447768116949137761
 MonoBehaviour:
@@ -300,7 +300,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ignoreLayerMask:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 128
 --- !u!114 &6848725594558035825
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -313,7 +313,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: db3466126358da44d9c6fac0264e332e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  enableHighlighting: 1
 --- !u!114 &589564064158956272
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -326,6 +325,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 50e71ef445a50ad48969053210d6bb86, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  editModeManager: {fileID: 0}
+  selectedObjectsManager: {fileID: 0}
 --- !u!114 &2951535440952928143
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -338,6 +339,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac29836f39176ec45af0e614a7ba33b2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  selectableObjectHighlighter: {fileID: 0}
 --- !u!1 &151350736762601885
 GameObject:
   m_ObjectHideFlags: 0
@@ -367,6 +369,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 151350736762601885}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -375,7 +378,6 @@ Transform:
   - {fileID: 4912725852084423976}
   - {fileID: 8380427711663556094}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!54 &5985767643881352044
 Rigidbody:
@@ -384,10 +386,21 @@ Rigidbody:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 151350736762601885}
-  serializedVersion: 2
+  serializedVersion: 4
   m_Mass: 1
   m_Drag: 5
   m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
   m_UseGravity: 0
   m_IsKinematic: 0
   m_Interpolate: 0
@@ -484,13 +497,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1678713438409449124}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4787269145028247440}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1509684546903082757
 MonoBehaviour:
@@ -544,13 +557,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2294620433214942771}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: -0.14, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4787269145028247440}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7494097142375895953
 MonoBehaviour:
@@ -616,13 +629,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3274418212045521117}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8380427711663556094}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &8989148317111106976
 MonoBehaviour:
@@ -676,13 +689,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3366587928214486604}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 4912725852084423976}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!20 &8348441568477808737
 Camera:
@@ -698,9 +711,17 @@ Camera:
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -765,9 +786,20 @@ MonoBehaviour:
   m_Dithering: 0
   m_ClearDepth: 1
   m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
   m_RequiresDepthTexture: 0
   m_RequiresColorTexture: 0
   m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
 --- !u!1 &3964283169820070414
 GameObject:
   m_ObjectHideFlags: 0
@@ -791,6 +823,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3964283169820070414}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0.51199996, z: 0.399}
   m_LocalScale: {x: 1.7241379, y: 1.7241379, z: 1.7241379}
@@ -799,7 +832,6 @@ Transform:
   - {fileID: 5955057430455588092}
   - {fileID: 2586828238354015427}
   m_Father: {fileID: 3668576700534163786}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5209944040320321953
 GameObject:
@@ -824,6 +856,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5209944040320321953}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -836,7 +869,6 @@ Transform:
   - {fileID: 4787269145028247440}
   - {fileID: 5510063321531201780}
   m_Father: {fileID: 750237606206558042}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5500969405214885589
 GameObject:
@@ -862,13 +894,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5500969405214885589}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8380427711663556094}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &3284399512722435954
 MonoBehaviour:
@@ -909,13 +941,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5682254833750392596}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4787269145028247440}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &360785854237697307
 MonoBehaviour:
@@ -967,6 +999,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5851380739034743552}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -977,7 +1010,6 @@ Transform:
   - {fileID: 2540911569476689856}
   - {fileID: 5216135092162279599}
   m_Father: {fileID: 8380427711663556094}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &550144965969967984
 MonoBehaviour:
@@ -1033,6 +1065,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7657426824907154042}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -1041,7 +1074,6 @@ Transform:
   - {fileID: 2199105442367158081}
   - {fileID: 3668576700534163786}
   m_Father: {fileID: 750237606206558042}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7674093451008853853
 GameObject:
@@ -1068,6 +1100,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7674093451008853853}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: -0.3, z: -0.18}
   m_LocalScale: {x: 0.58, y: 0.58, z: 0.58}
@@ -1075,7 +1108,6 @@ Transform:
   m_Children:
   - {fileID: 8424176746612216539}
   m_Father: {fileID: 4912725852084423976}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &7974978009183572120
 MeshFilter:
@@ -1151,13 +1183,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8168548999095849830}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8380427711663556094}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &8609995128081157354
 MonoBehaviour:

--- a/Assets/ScriptHolders/Character.prefab
+++ b/Assets/ScriptHolders/Character.prefab
@@ -780,7 +780,7 @@ MonoBehaviour:
   m_VolumeTrigger: {fileID: 0}
   m_VolumeFrameworkUpdateModeOption: 2
   m_RenderPostProcessing: 1
-  m_Antialiasing: 2
+  m_Antialiasing: 3
   m_AntialiasingQuality: 2
   m_StopNaN: 0
   m_Dithering: 0
@@ -799,7 +799,7 @@ MonoBehaviour:
     m_JitterScale: 1
     m_MipBias: 0
     m_VarianceClampScale: 0.9
-    m_ContrastAdaptiveSharpening: 0
+    m_ContrastAdaptiveSharpening: 1
 --- !u!1 &3964283169820070414
 GameObject:
   m_ObjectHideFlags: 0

--- a/Runtime/DependencyInjectors/SensedObjectHighlighterDependencyInjector.cs
+++ b/Runtime/DependencyInjectors/SensedObjectHighlighterDependencyInjector.cs
@@ -22,7 +22,7 @@ namespace ReupVirtualTwin.dependencyInjectors
 
             SensedObjectHighlighter selectableObjectHighlighter = GetComponent<SensedObjectHighlighter>();
             selectableObjectHighlighter.objectSensor = objectSensor;
-            selectableObjectHighlighter.objectHighlighter = new Outliner(RomuloEnvironment.orangeHighlightColor, 5.0f);
+            selectableObjectHighlighter.objectHighlighter = new HaloApplier();
 
             SelectableObjectsHighlighterEnabler selectableObjectHighlighterEnabler = GetComponent<SelectableObjectsHighlighterEnabler>();
             selectableObjectHighlighterEnabler.selectableObjectHighlighter = selectableObjectHighlighter;

--- a/Runtime/Helpers/HaloApplier.cs
+++ b/Runtime/Helpers/HaloApplier.cs
@@ -1,0 +1,48 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using ReupVirtualTwin.helperInterfaces;
+
+namespace ReupVirtualTwin.helpers
+{
+    public class HaloApplier : IObjectHighlighter
+    {
+        public Color emissionColor = Color.white;
+        public float emissionIntensity = 0.01f;
+        public void HighlightObject(GameObject obj)
+        {
+            Renderer renderer = obj.GetComponent<Renderer>();
+            if (renderer != null)
+            {
+                Material material = renderer.material;
+                if (material != null)
+                {
+                    Color finalColor = emissionColor * Mathf.LinearToGammaSpace(emissionIntensity);
+                    material.SetColor("_EmissionColor", finalColor);
+                    material.EnableKeyword("_EMISSION");
+                }
+            }
+            foreach (Transform child in obj.transform)
+            {
+                HighlightObject(child.gameObject);
+            }
+        }
+
+        public void UnhighlightObject(GameObject obj)
+        {
+            Renderer renderer = obj.GetComponent<Renderer>();
+            if (renderer != null)
+            {
+                Material material = renderer.material;
+                if (material != null)
+                {
+                    material.DisableKeyword("_EMISSION");
+                }
+            }
+            foreach (Transform child in obj.transform)
+            {
+                UnhighlightObject(child.gameObject);
+            }
+        }
+    }
+}

--- a/Runtime/Helpers/HaloApplier.cs.meta
+++ b/Runtime/Helpers/HaloApplier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1723d0515c9aea745920c5875d4a4fa5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "unity": "2019.1",
   "dependencies": {
     "com.unity.inputsystem": "1.5.1",
-    "com.unity.render-pipelines.universal": "12.1.11",
     "com.unity.test-framework": "2.0.1-exp.1"
   },
   "keywords": [],


### PR DESCRIPTION
[Reup344](https://macheight-reup.atlassian.net/browse/REUP-344?atlOrigin=eyJpIjoiN2YzODcyOWU4YjYwNDMyNjg0OWJjMzgzNTZlNzcyMjQiLCJwIjoiaiJ9)

As a user, I would like the mouse over on a selectable object to put a soft highlight on the whole object instead of just showing the outline of the object so that it’s easier to understand what object you’re selecting

AC:

The highlight the border on mouse over effect is changed to make the entire object glow subtly

Hidden parts of the highlighted object remain hidden

