### PR TITLE
Reup344 highlight all selectable objects

### DIFF
--- a/Assets/Materials/Colors/CharacterCollor.mat
+++ b/Assets/Materials/Colors/CharacterCollor.mat
@@ -9,6 +9,8 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: CharacterCollor
   m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
@@ -18,6 +20,7 @@ Material:
   stringTagMap:
     RenderType: Opaque
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -80,7 +83,9 @@ Material:
     m_Ints: []
     m_Floats:
     - _AlphaClip: 0
+    - _AlphaToMask: 0
     - _Blend: 0
+    - _BlendModePreserveSpecular: 1
     - _BumpScale: 1
     - _ClearCoatMask: 0
     - _ClearCoatSmoothness: 0
@@ -89,6 +94,7 @@ Material:
     - _DetailAlbedoMapScale: 1
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
+    - _DstBlendAlpha: 0
     - _EnvironmentReflections: 1
     - _GlossMapScale: 1
     - _Glossiness: 0.5
@@ -103,13 +109,14 @@ Material:
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
     - _Surface: 0
     - _UVSec: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:
     - _BaseColor: {r: 0, g: 0.8679245, b: 0.09605073, a: 1}
-    - _Color: {r: 0, g: 0.8679245, b: 0.09605069, a: 1}
+    - _Color: {r: 0, g: 0.8679245, b: 0.09605073, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
   m_BuildTextureStacks: []
@@ -125,4 +132,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  version: 5
+  version: 7

--- a/Assets/Materials/Colors/ReupBlue.mat
+++ b/Assets/Materials/Colors/ReupBlue.mat
@@ -9,6 +9,8 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: ReupBlue
   m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
@@ -18,6 +20,7 @@ Material:
   stringTagMap:
     RenderType: Opaque
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -80,7 +83,9 @@ Material:
     m_Ints: []
     m_Floats:
     - _AlphaClip: 0
+    - _AlphaToMask: 0
     - _Blend: 0
+    - _BlendModePreserveSpecular: 1
     - _BumpScale: 1
     - _ClearCoatMask: 0
     - _ClearCoatSmoothness: 0
@@ -89,6 +94,7 @@ Material:
     - _DetailAlbedoMapScale: 1
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
+    - _DstBlendAlpha: 0
     - _EnvironmentReflections: 1
     - _GlossMapScale: 1
     - _Glossiness: 0.5
@@ -103,13 +109,14 @@ Material:
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
     - _Surface: 0
     - _UVSec: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:
     - _BaseColor: {r: 0.14509805, g: 0.5882353, b: 0.74509805, a: 1}
-    - _Color: {r: 0.145098, g: 0.5882353, b: 0.74509805, a: 1}
+    - _Color: {r: 0.14509805, g: 0.5882353, b: 0.74509805, a: 1}
     - _EmissionColor: {r: 0.03627451, g: 0.14705883, b: 0.18627451, a: 1}
     - _SpecColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}
   m_BuildTextureStacks: []
@@ -125,4 +132,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  version: 5
+  version: 7

--- a/Assets/ScriptHolders/SelectedObjectsManager.prefab
+++ b/Assets/ScriptHolders/SelectedObjectsManager.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 2557996600432680719}
   - component: {fileID: 4879889724370832318}
   - component: {fileID: 7328548031457494451}
+  - component: {fileID: 5787676555039878621}
   m_Layer: 0
   m_Name: SelectedObjectsManager
   m_TagString: Untagged
@@ -28,13 +29,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4786376132976531946}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1186984941053318017
 MonoBehaviour:
@@ -100,3 +101,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 94d201b0f7137bc4facb3a894929b988, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &5787676555039878621
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4786376132976531946}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c857d9ebd9dc65442b00674998a8730e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TIME_TO_HIGHLIGHT_IN_SECS: 0.4
+  TIME_TO_UNHIGHLIGHT_IN_SECS: 1
+  INITIAL_INTENSITY: 0
+  FINAL_INTENSITY: 0.015

--- a/Runtime/Behaviours/Select/SelectSelectableObject.cs
+++ b/Runtime/Behaviours/Select/SelectSelectableObject.cs
@@ -10,10 +10,14 @@ namespace ReupVirtualTwin.behaviours
     public class SelectSelectableObject : SelectObject
     {
         ISelectedObjectsManager _selectedObjectsManager;
+        ISelectableObjectsHighlighter _selectableObjectsHighlighter;
+        public ISelectableObjectsHighlighter selectableObjectsHighlighter { set { _selectableObjectsHighlighter = value; } }
         override protected void Start()
         {
+            Debug.Log("in start");
             base.Start();
             _selectedObjectsManager = GetComponent<ISelectedObjectsManager>();
+            Debug.Log("end of start");
         }
         public override void HandleObject(GameObject obj)
         {
@@ -23,6 +27,13 @@ namespace ReupVirtualTwin.behaviours
                 return;
             }
             _selectedObjectsManager.AddObjectToSelection(obj);
+        }
+        public override void MissObject()
+        {
+            if (_selectedObjectsManager.allowEditSelection)
+            {
+                _selectableObjectsHighlighter.HighlightSelectableObjects();
+            }
         }
     }
 }

--- a/Runtime/Behaviours/Select/SelectSelectableObject.cs
+++ b/Runtime/Behaviours/Select/SelectSelectableObject.cs
@@ -11,13 +11,16 @@ namespace ReupVirtualTwin.behaviours
     {
         ISelectedObjectsManager _selectedObjectsManager;
         ISelectableObjectsHighlighter _selectableObjectsHighlighter;
-        public ISelectableObjectsHighlighter selectableObjectsHighlighter { set { _selectableObjectsHighlighter = value; } }
+        public ISelectableObjectsHighlighter selectableObjectsHighlighter
+        {
+            get { return  _selectableObjectsHighlighter; }
+            set { _selectableObjectsHighlighter = value; }
+        }
         override protected void Start()
         {
-            Debug.Log("in start");
             base.Start();
             _selectedObjectsManager = GetComponent<ISelectedObjectsManager>();
-            Debug.Log("end of start");
+            _selectableObjectsHighlighter = GetComponent<ISelectableObjectsHighlighter>();
         }
         public override void HandleObject(GameObject obj)
         {

--- a/Runtime/DependencyInjectors/SelectedObjectsManagerDependencyInjector.cs
+++ b/Runtime/DependencyInjectors/SelectedObjectsManagerDependencyInjector.cs
@@ -6,6 +6,7 @@ using ReupVirtualTwin.managers;
 using ReupVirtualTwin.controllers;
 using ReupVirtualTwin.romuloEnvironment;
 using ReupVirtualTwin.modelInterfaces;
+using ReupVirtualTwin.helperInterfaces;
 
 namespace ReupVirtualTwin.dependencyInjectors
 {
@@ -24,7 +25,7 @@ namespace ReupVirtualTwin.dependencyInjectors
             SelectableObjectSelector selector = GetComponent<SelectableObjectSelector>();
             selector.tagsController = new TagsController();
 
-            selectedObjectsManager.highlightAnimator = new HighlightAnimator();
+            selectedObjectsManager.highlightAnimator = GetComponent<IHighlightAnimator>();
             IObjectRegistry registry = ObjectFinder.FindObjectRegistry().GetComponent<IObjectRegistry>();
             selectedObjectsManager.objectRegistry = registry;
             selectedObjectsManager.tagsController = new TagsController();

--- a/Runtime/DependencyInjectors/SelectedObjectsManagerDependencyInjector.cs
+++ b/Runtime/DependencyInjectors/SelectedObjectsManagerDependencyInjector.cs
@@ -5,6 +5,7 @@ using ReupVirtualTwin.managerInterfaces;
 using ReupVirtualTwin.managers;
 using ReupVirtualTwin.controllers;
 using ReupVirtualTwin.romuloEnvironment;
+using ReupVirtualTwin.modelInterfaces;
 
 namespace ReupVirtualTwin.dependencyInjectors
 {
@@ -22,6 +23,11 @@ namespace ReupVirtualTwin.dependencyInjectors
 
             SelectableObjectSelector selector = GetComponent<SelectableObjectSelector>();
             selector.tagsController = new TagsController();
+
+            selectedObjectsManager.highlightAnimator = new HighlightAnimator();
+            IObjectRegistry registry = ObjectFinder.FindObjectRegistry().GetComponent<IObjectRegistry>();
+            selectedObjectsManager.objectRegistry = registry;
+            selectedObjectsManager.tagsController = new TagsController();
         }
     }
 }

--- a/Runtime/HelperInterfaces/IHighlightAnimator.cs
+++ b/Runtime/HelperInterfaces/IHighlightAnimator.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ReupVirtualTwin.helperInterfaces
+{
+    public interface IHighlightAnimator
+    {
+        public void HighlighObjectsEaseInEaseOut(List<GameObject> objs);
+    }
+}

--- a/Runtime/HelperInterfaces/IHighlightAnimator.cs.meta
+++ b/Runtime/HelperInterfaces/IHighlightAnimator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db227c81f06a7644a8885e3c884121ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Helpers/HighlightAnimator.cs
+++ b/Runtime/Helpers/HighlightAnimator.cs
@@ -20,6 +20,7 @@ namespace ReupVirtualTwin.helpers
 
         public void HighlighObjectsEaseInEaseOut(List<GameObject> objs)
         {
+            StopAllCoroutines();
             StartCoroutine("DoAnimation", objs);
         }
 

--- a/Runtime/Helpers/HighlightAnimator.cs
+++ b/Runtime/Helpers/HighlightAnimator.cs
@@ -1,0 +1,22 @@
+using ReupVirtualTwin.helperInterfaces;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ReupVirtualTwin.helpers
+{
+    public class HighlightAnimator : IHighlightAnimator
+    {
+        HaloApplier haloApplier;
+
+        public HighlightAnimator()
+        {
+            haloApplier = new HaloApplier();
+        }
+
+        public void HighlighObjectsEaseInEaseOut(List<GameObject> objs)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/Runtime/Helpers/HighlightAnimator.cs
+++ b/Runtime/Helpers/HighlightAnimator.cs
@@ -5,9 +5,13 @@ using UnityEngine;
 
 namespace ReupVirtualTwin.helpers
 {
-    public class HighlightAnimator : IHighlightAnimator
+    public class HighlightAnimator : MonoBehaviour, IHighlightAnimator
     {
         HaloApplier haloApplier;
+        public float TIME_TO_HIGHLIGHT_IN_SECS = 0.4f;
+        public float TIME_TO_UNHIGHLIGHT_IN_SECS = 1.0f;
+        public float INITIAL_INTENSITY = 0.0f;
+        public float FINAL_INTENSITY = 0.015f;
 
         public HighlightAnimator()
         {
@@ -16,7 +20,54 @@ namespace ReupVirtualTwin.helpers
 
         public void HighlighObjectsEaseInEaseOut(List<GameObject> objs)
         {
-            throw new System.NotImplementedException();
+            StartCoroutine("DoAnimation", objs);
+        }
+
+        private IEnumerator DoAnimation(List<GameObject> objs)
+        {
+            yield return StartCoroutine("HighlightObjectsCoroutine", objs);
+            yield return StartCoroutine("UnhighlightObjectsCoroutine", objs);
+            UnhighlightObject(objs);
+        }
+
+        private IEnumerator HighlightObjectsCoroutine(List<GameObject> objs)
+        {
+            haloApplier.emissionIntensity = INITIAL_INTENSITY;
+            var endTime = Time.time + TIME_TO_HIGHLIGHT_IN_SECS;
+            float intensityDistance = FINAL_INTENSITY - haloApplier.emissionIntensity;
+            while (Time.time < endTime)
+            {
+                float deltaIntensity = intensityDistance * Time.deltaTime / (TIME_TO_HIGHLIGHT_IN_SECS);
+                haloApplier.emissionIntensity += deltaIntensity;
+                HighlightObject(objs);
+                yield return null;
+            }
+        }
+        private IEnumerator UnhighlightObjectsCoroutine(List<GameObject> objs)
+        {
+            var endTime = Time.time + TIME_TO_UNHIGHLIGHT_IN_SECS;
+            float intensityDistance = haloApplier.emissionIntensity - INITIAL_INTENSITY;
+            while (Time.time < endTime)
+            {
+                float deltaIntensity = intensityDistance * Time.deltaTime / (TIME_TO_HIGHLIGHT_IN_SECS);
+                haloApplier.emissionIntensity -= deltaIntensity;
+                HighlightObject(objs);
+                yield return null;
+            }
+        }
+        private void HighlightObject(List<GameObject> objs)
+        {
+            foreach (var obj in objs)
+            {
+                haloApplier.HighlightObject(obj);
+            }
+        }
+        private void UnhighlightObject(List<GameObject> objs)
+        {
+            foreach (var obj in objs)
+            {
+                haloApplier.UnhighlightObject(obj);
+            }
         }
     }
 }

--- a/Runtime/Helpers/HighlightAnimator.cs.meta
+++ b/Runtime/Helpers/HighlightAnimator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c857d9ebd9dc65442b00674998a8730e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/ManagerInterfaces/ISelectableObjectsHighlighter.cs
+++ b/Runtime/ManagerInterfaces/ISelectableObjectsHighlighter.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ReupVirtualTwin.managerInterfaces
+{
+    public interface ISelectableObjectsHighlighter
+    {
+        public void HighlightSelectableObjects();
+    }
+}

--- a/Runtime/ManagerInterfaces/ISelectableObjectsHighlighter.cs.meta
+++ b/Runtime/ManagerInterfaces/ISelectableObjectsHighlighter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6992af293ccfed34d8bfd192d996aa53
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Managers/SelectedObjectsManager.cs
+++ b/Runtime/Managers/SelectedObjectsManager.cs
@@ -1,12 +1,15 @@
 using UnityEngine;
+using System.Collections.Generic;
+using System;
+using System.Linq;
 
 using ReupVirtualTwin.managerInterfaces;
 using ReupVirtualTwin.helpers;
 using ReupVirtualTwin.helperInterfaces;
 using ReupVirtualTwin.enums;
 using ReupVirtualTwin.dataModels;
-using System.Collections.Generic;
-using System;
+using ReupVirtualTwin.modelInterfaces;
+using ReupVirtualTwin.controllerInterfaces;
 
 namespace ReupVirtualTwin.managers
 {
@@ -20,6 +23,11 @@ namespace ReupVirtualTwin.managers
         public IObjectHighlighter highlighter { set => _highlighter = value; }
         private IMediator _mediator;
         public IMediator mediator { set { _mediator = value; } }
+        public IHighlightAnimator highlightAnimator { get; set; }
+        public IObjectRegistry objectRegistry { get; set; }
+
+        public ITagsController tagsController { get; set; }
+
         private GameObject _wrapperObject;
         private GameObject wrapperObject
         {
@@ -98,7 +106,10 @@ namespace ReupVirtualTwin.managers
 
         public void HighlightSelectableObjects()
         {
-            throw new NotImplementedException();
+            List<GameObject> selectableObjects = objectRegistry.GetObjects()
+                .Where(obj => tagsController.DoesObjectHaveTag(obj, EditionTagsCreator.CreateSelectableTag().id))
+                .ToList();
+            highlightAnimator.HighlighObjectsEaseInEaseOut(selectableObjects);
         }
     }
 }

--- a/Runtime/Managers/SelectedObjectsManager.cs
+++ b/Runtime/Managers/SelectedObjectsManager.cs
@@ -11,6 +11,7 @@ using System;
 namespace ReupVirtualTwin.managers
 {
     public class SelectedObjectsManager : MonoBehaviour, ISelectedObjectsManager, IIsObjectPartOfSelection, IOnAllowSelectionChange
+        ,ISelectableObjectsHighlighter
     {
         public event Action<bool> AllowSelectionChanged;
         private IObjectWrapper _objectWrapper;
@@ -93,6 +94,11 @@ namespace ReupVirtualTwin.managers
         {
             List<GameObject> selectedObjects = _objectWrapper.wrappedObjects;
             return GameObjectUtils.IsPartOf(selectedObjects, obj);
+        }
+
+        public void HighlightSelectableObjects()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/Runtime/ModelInterfaces/IObjectRegistry.cs
+++ b/Runtime/ModelInterfaces/IObjectRegistry.cs
@@ -10,6 +10,7 @@ namespace ReupVirtualTwin.modelInterfaces
         public GameObject GetObjectWithGuid(string guid);
         public List<GameObject> GetObjectsWithGuids(string[] guids);
         public int GetObjectsCount();
+        public List<GameObject> GetObjects();
         public void ClearRegistry();
     }
 }

--- a/Runtime/Models/ObjectRegistry.cs
+++ b/Runtime/Models/ObjectRegistry.cs
@@ -54,5 +54,10 @@ namespace ReupVirtualTwin.models
         {
             objects.Clear();
         }
+        
+        public List<GameObject> GetObjects()
+        {
+            return objects;
+        }
     }
 }

--- a/Runtime/TriLib/TriLibUniversalRP/Resources/Materials/UniversalRP/Standard/TriLibUniversalRP.mat
+++ b/Runtime/TriLib/TriLibUniversalRP/Resources/Materials/UniversalRP/Standard/TriLibUniversalRP.mat
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  version: 5
+  version: 7
 --- !u!21 &2100000
 Material:
   serializedVersion: 8
@@ -22,6 +22,8 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: TriLibUniversalRP
   m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - _EMISSION
   - _METALLICSPECGLOSSMAP
@@ -35,6 +37,7 @@ Material:
   stringTagMap:
     RenderType: Opaque
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -97,7 +100,9 @@ Material:
     m_Ints: []
     m_Floats:
     - _AlphaClip: 0
+    - _AlphaToMask: 0
     - _Blend: 0
+    - _BlendModePreserveSpecular: 1
     - _BumpScale: 1
     - _ClearCoatMask: 0
     - _ClearCoatSmoothness: 0
@@ -106,6 +111,7 @@ Material:
     - _DetailAlbedoMapScale: 1
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
+    - _DstBlendAlpha: 0
     - _EnvironmentReflections: 1
     - _GlossMapScale: 1
     - _Glossiness: 0.5
@@ -120,6 +126,7 @@ Material:
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
     - _Surface: 0
     - _UVSec: 0
     - _WorkflowMode: 1

--- a/Runtime/TriLib/TriLibUniversalRP/Resources/Materials/UniversalRP/Standard/TriLibUniversalRPAlpha.mat
+++ b/Runtime/TriLib/TriLibUniversalRP/Resources/Materials/UniversalRP/Standard/TriLibUniversalRPAlpha.mat
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  version: 5
+  version: 7
 --- !u!21 &2100000
 Material:
   serializedVersion: 8
@@ -22,6 +22,8 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: TriLibUniversalRPAlpha
   m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - _EMISSION
   - _METALLICSPECGLOSSMAP
@@ -38,6 +40,7 @@ Material:
   disabledShaderPasses:
   - SHADOWCASTER
   - DepthOnly
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -100,7 +103,9 @@ Material:
     m_Ints: []
     m_Floats:
     - _AlphaClip: 0
+    - _AlphaToMask: 0
     - _Blend: 0
+    - _BlendModePreserveSpecular: 0
     - _BumpScale: 1
     - _ClearCoatMask: 0
     - _ClearCoatSmoothness: 0
@@ -109,6 +114,7 @@ Material:
     - _DetailAlbedoMapScale: 1
     - _DetailNormalMapScale: 1
     - _DstBlend: 10
+    - _DstBlendAlpha: 10
     - _EnvironmentReflections: 1
     - _GlossMapScale: 1
     - _Glossiness: 0.5
@@ -125,6 +131,7 @@ Material:
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 5
+    - _SrcBlendAlpha: 1
     - _Surface: 1
     - _TRANSPARENCY: 1
     - _TYPE: 0

--- a/Runtime/TriLib/TriLibUniversalRP/Resources/Materials/UniversalRP/Standard/TriLibUniversalRPAlphaCutout.mat
+++ b/Runtime/TriLib/TriLibUniversalRP/Resources/Materials/UniversalRP/Standard/TriLibUniversalRPAlphaCutout.mat
@@ -9,6 +9,8 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: TriLibUniversalRPAlphaCutout
   m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - _ALPHATEST_ON
   - _EMISSION
@@ -23,6 +25,7 @@ Material:
   stringTagMap:
     RenderType: TransparentCutout
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -85,7 +88,9 @@ Material:
     m_Ints: []
     m_Floats:
     - _AlphaClip: 1
+    - _AlphaToMask: 1
     - _Blend: 0
+    - _BlendModePreserveSpecular: 1
     - _BumpScale: 1
     - _ClearCoatMask: 0
     - _ClearCoatSmoothness: 0
@@ -94,6 +99,7 @@ Material:
     - _DetailAlbedoMapScale: 1
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
+    - _DstBlendAlpha: 0
     - _EnvironmentReflections: 1
     - _GlossMapScale: 1
     - _Glossiness: 0.5
@@ -108,6 +114,7 @@ Material:
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
     - _Surface: 0
     - _UVSec: 0
     - _WorkflowMode: 1
@@ -130,4 +137,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  version: 5
+  version: 7

--- a/Runtime/TriLib/TriLibUniversalRP/Resources/Materials/UniversalRP/TriLibUniversalRPLoading.mat
+++ b/Runtime/TriLib/TriLibUniversalRP/Resources/Materials/UniversalRP/TriLibUniversalRPLoading.mat
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  version: 5
+  version: 7
 --- !u!21 &2100000
 Material:
   serializedVersion: 8
@@ -22,6 +22,8 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: TriLibUniversalRPLoading
   m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
@@ -31,6 +33,7 @@ Material:
   stringTagMap:
     RenderType: Opaque
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -93,7 +96,9 @@ Material:
     m_Ints: []
     m_Floats:
     - _AlphaClip: 0
+    - _AlphaToMask: 0
     - _Blend: 0
+    - _BlendModePreserveSpecular: 1
     - _BumpScale: 1
     - _ClearCoatMask: 0
     - _ClearCoatSmoothness: 0
@@ -102,6 +107,7 @@ Material:
     - _DetailAlbedoMapScale: 1
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
+    - _DstBlendAlpha: 0
     - _EnvironmentReflections: 1
     - _GlossMapScale: 1
     - _Glossiness: 0
@@ -116,6 +122,7 @@ Material:
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
     - _Surface: 0
     - _UVSec: 0
     - _WorkflowMode: 1

--- a/Tests/PlayMode/DeleteObjectsManagerTest.cs
+++ b/Tests/PlayMode/DeleteObjectsManagerTest.cs
@@ -152,6 +152,11 @@ public class DeleteObjectsManagerTest : MonoBehaviour
         {
             throw new NotImplementedException();
         }
+
+        public List<GameObject> GetObjects()
+        {
+            throw new NotImplementedException();
+        }
     }
 
 }

--- a/Tests/PlayMode/HighlightSelectableObjectTest.cs
+++ b/Tests/PlayMode/HighlightSelectableObjectTest.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using UnityEngine;
 using UnityEngine.TestTools;
 
-using ReupVirtualTwin.managers;
 using ReupVirtualTwin.behaviours;
 using ReupVirtualTwin.managerInterfaces;
 

--- a/Tests/PlayMode/HighlightSelectableObjectTest.cs
+++ b/Tests/PlayMode/HighlightSelectableObjectTest.cs
@@ -1,0 +1,62 @@
+using NUnit.Framework;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+using ReupVirtualTwin.managers;
+using ReupVirtualTwin.behaviours;
+using ReupVirtualTwin.managerInterfaces;
+
+namespace ReupVirtualTwinTests
+{
+    public class HighlightSelectableObjectTest : MonoBehaviour
+    {
+        ReupSceneInstantiator.SceneObjects sceneObjects;
+        SelectSelectableObject selectSelectableObjectBehavior;
+        SelectableObjectHighlighterMock selectableObjectHighligherMock;
+
+        [UnitySetUp]
+        public IEnumerator SetUp()
+        {
+            sceneObjects = ReupSceneInstantiator.InstantiateScene();
+            selectSelectableObjectBehavior = sceneObjects.selectSelectableObject;
+            yield return null; // this yield is necessary so all game objects run the Start() method
+            selectableObjectHighligherMock = new SelectableObjectHighlighterMock();
+            selectSelectableObjectBehavior.selectableObjectsHighlighter = selectableObjectHighligherMock;
+        }
+
+        [UnityTearDown]
+        public IEnumerator TearDown()
+        {
+            ReupSceneInstantiator.DestroySceneObjects(sceneObjects);
+            yield return null;
+        }
+
+        class SelectableObjectHighlighterMock : ISelectableObjectsHighlighter
+        {
+            public bool highlighRequested = false;
+            public void HighlightSelectableObjects()
+            {
+                highlighRequested = true;
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator ShouldNotHighlightSelectableObjects_When_Tap_AndNot_InEditMode()
+        {
+            ReupSceneInstantiator.SetEditMode(sceneObjects, false);
+            selectSelectableObjectBehavior.MissObject();
+            yield return null;
+            Assert.IsFalse(selectableObjectHighligherMock.highlighRequested);
+        }
+
+        [UnityTest]
+        public IEnumerator ShouldHighlightSelectableObjects_When_Tap_And_InEditMode()
+        {
+            ReupSceneInstantiator.SetEditMode(sceneObjects, true);
+            selectSelectableObjectBehavior.MissObject();
+            yield return null;
+            Assert.IsTrue(selectableObjectHighligherMock.highlighRequested);
+        }
+    }
+}

--- a/Tests/PlayMode/HighlightSelectableObjectTest.cs.meta
+++ b/Tests/PlayMode/HighlightSelectableObjectTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 42c2d9f36b4d2f54d98c7057dff0c23b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/Mocks/ObjectRegistrySpy.cs
+++ b/Tests/PlayMode/Mocks/ObjectRegistrySpy.cs
@@ -1,7 +1,9 @@
-using ReupVirtualTwin.modelInterfaces;
-using ReupVirtualTwin.models;
 using System.Collections.Generic;
 using UnityEngine;
+
+using ReupVirtualTwin.modelInterfaces;
+using ReupVirtualTwin.models;
+using ReupVirtualTwin.controllers;
 
 namespace Tests.PlayMode.Mocks
 {
@@ -10,6 +12,7 @@ namespace Tests.PlayMode.Mocks
         public List<GameObject> objects = new List<GameObject>();
         public string[] lastRequestedObjectIds;
         public List<string[]> requestedObjectIds;
+        private TagSystemController tagSystemController = new TagSystemController();
         public ObjectRegistrySpy()
         {
             for (int i = 0; i < 10; i++)
@@ -17,6 +20,7 @@ namespace Tests.PlayMode.Mocks
                 GameObject obj = new();
                 obj.AddComponent<UniqueId>().GenerateId();
                 objects.Add(obj);
+                tagSystemController.AssignTagSystemToObject(obj);
             }
             requestedObjectIds = new List<string[]>();
         }
@@ -28,6 +32,11 @@ namespace Tests.PlayMode.Mocks
         public void ClearRegistry()
         {
             throw new System.NotImplementedException();
+        }
+
+        public List<GameObject> GetObjects()
+        {
+            return objects;
         }
 
         public int GetObjectsCount()

--- a/Tests/PlayMode/Mocks/SomeObjectWithMaterialRegistrySpy.cs
+++ b/Tests/PlayMode/Mocks/SomeObjectWithMaterialRegistrySpy.cs
@@ -60,5 +60,10 @@ namespace Tests.PlayMode.Mocks
                 Object.Destroy(objects[i]);
             }
         }
+
+        public List<GameObject> GetObjects()
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }

--- a/Tests/PlayMode/ReupPrefabTest.cs
+++ b/Tests/PlayMode/ReupPrefabTest.cs
@@ -7,6 +7,7 @@ using ReupVirtualTwin.managers;
 using ReupVirtualTwin.modelInterfaces;
 using ReupVirtualTwin.behaviours;
 using ReupVirtualTwin.helpers;
+using ReupVirtualTwin.managerInterfaces;
 
 public class ReupPrefabTest : MonoBehaviour
 {
@@ -105,6 +106,14 @@ public class ReupPrefabTest : MonoBehaviour
         editModeManager.editMode = false;
         yield return null;
         Assert.IsFalse(selectableObjectHighlighter.enableHighlighting);
+        yield return null;
+    }
+
+    [UnityTest]
+    public IEnumerator SelectSElectableObject_ShouldHaveA_ISelectableObjectsHighlighter()
+    {
+        ISelectableObjectsHighlighter selectableObjectsHighlighter = sceneObjects.selectSelectableObject.selectableObjectsHighlighter;
+        Assert.IsNotNull(selectableObjectsHighlighter);
         yield return null;
     }
 

--- a/Tests/PlayMode/ReupPrefabTest.cs
+++ b/Tests/PlayMode/ReupPrefabTest.cs
@@ -8,6 +8,7 @@ using ReupVirtualTwin.modelInterfaces;
 using ReupVirtualTwin.behaviours;
 using ReupVirtualTwin.helpers;
 using ReupVirtualTwin.managerInterfaces;
+using ReupVirtualTwin.helperInterfaces;
 
 public class ReupPrefabTest : MonoBehaviour
 {
@@ -110,10 +111,26 @@ public class ReupPrefabTest : MonoBehaviour
     }
 
     [UnityTest]
-    public IEnumerator SelectSElectableObject_ShouldHaveA_ISelectableObjectsHighlighter()
+    public IEnumerator SelectSelectableObject_ShouldHaveA_ISelectableObjectsHighlighter()
     {
         ISelectableObjectsHighlighter selectableObjectsHighlighter = sceneObjects.selectSelectableObject.selectableObjectsHighlighter;
         Assert.IsNotNull(selectableObjectsHighlighter);
+        yield return null;
+    }
+
+    [UnityTest]
+    public IEnumerator SelectObjectManager_ShouldHaveA_IHighlightAnimator()
+    {
+        IHighlightAnimator highlightAnimator = sceneObjects.selectedObjectsManager.highlightAnimator;
+        Assert.IsNotNull(highlightAnimator);
+        yield return null;
+    }
+
+    [UnityTest]
+    public IEnumerator SelectObjectManager_ShouldHaveA_IObjectRegistry()
+    {
+        IObjectRegistry objectRegistry = sceneObjects.selectedObjectsManager.objectRegistry;
+        Assert.IsNotNull(objectRegistry);
         yield return null;
     }
 

--- a/Tests/PlayMode/Utils/ReupSceneInstantiator.cs
+++ b/Tests/PlayMode/Utils/ReupSceneInstantiator.cs
@@ -1,6 +1,7 @@
 using ReupVirtualTwin.behaviourInterfaces;
 using ReupVirtualTwin.managers;
 using ReupVirtualTwin.models;
+using ReupVirtualTwin.behaviours;
 using UnityEditor;
 using UnityEngine;
 
@@ -14,6 +15,7 @@ public static class ReupSceneInstantiator
         public GameObject baseGlobalScriptGameObject;
         public GameObject building;
         public ChangeColorManager changeColorManager;
+        public SelectSelectableObject selectSelectableObject;
     }
 
     public static SceneObjects InstantiateScene()
@@ -32,6 +34,11 @@ public static class ReupSceneInstantiator
             .Find("ChangeColorManager")
             .GetComponent<ChangeColorManager>();
 
+         SelectSelectableObject selectSelectableObject = baseGlobalScriptGameObject.transform
+            .Find("EditMediator")
+            .Find("SelectedObjectsManager")
+            .GetComponent<SelectSelectableObject>();
+
         return new SceneObjects
         {
             reupObject = reupGameObject,
@@ -39,6 +46,7 @@ public static class ReupSceneInstantiator
             baseGlobalScriptGameObject = baseGlobalScriptGameObject,
             building = building,
             changeColorManager = changeColorManager,
+            selectSelectableObject = selectSelectableObject,
         };
     }
 
@@ -46,5 +54,14 @@ public static class ReupSceneInstantiator
     {
         Object.Destroy(sceneObjects.reupObject);
         Object.Destroy(sceneObjects.building);
+    }
+
+    public static void SetEditMode(SceneObjects sceneObjects, bool editMode)
+    {
+        EditModeManager editModeManager = sceneObjects.baseGlobalScriptGameObject.transform
+            .Find("EditMediator")
+            .Find("EditModeManager")
+            .GetComponent<EditModeManager>();
+        editModeManager.editMode = editMode;
     }
 }

--- a/Tests/PlayMode/Utils/ReupSceneInstantiator.cs
+++ b/Tests/PlayMode/Utils/ReupSceneInstantiator.cs
@@ -16,6 +16,7 @@ public static class ReupSceneInstantiator
         public GameObject building;
         public ChangeColorManager changeColorManager;
         public SelectSelectableObject selectSelectableObject;
+        public SelectedObjectsManager selectedObjectsManager;
     }
 
     public static SceneObjects InstantiateScene()
@@ -39,6 +40,11 @@ public static class ReupSceneInstantiator
             .Find("SelectedObjectsManager")
             .GetComponent<SelectSelectableObject>();
 
+         SelectedObjectsManager selectedObjectsManager = baseGlobalScriptGameObject.transform
+            .Find("EditMediator")
+            .Find("SelectedObjectsManager")
+            .GetComponent<SelectedObjectsManager>();
+
         return new SceneObjects
         {
             reupObject = reupGameObject,
@@ -47,6 +53,7 @@ public static class ReupSceneInstantiator
             building = building,
             changeColorManager = changeColorManager,
             selectSelectableObject = selectSelectableObject,
+            selectedObjectsManager = selectedObjectsManager,
         };
     }
 


### PR DESCRIPTION
[Reup344](https://macheight-reup.atlassian.net/browse/REUP-343?atlOrigin=eyJpIjoiN2QwYWUzYmIyNWZhNGNmMmFiNWI3NTYxOGExNThhNjQiLCJwIjoiaiJ9)

As a user, I would like it if tapping on a non-selectable object while in edit mode highlights selectable objects so that I can easily determine which objects in the scene are selectable

AC:

When in edit mode and the clicks (taps) on a non-selectable object in the scene, all selectable objects briefly highlight

The effect should be similar to how the figma prototypes work to show the user things they can click on