### PR TITLE
Reup377 restore objects visibility

### DIFF
--- a/Editor/TagScannerTool.cs
+++ b/Editor/TagScannerTool.cs
@@ -82,11 +82,6 @@ namespace ReupVirtualTwin.editor
             EditorGUILayout.EndHorizontal();
         }
 
-        private void SaveCurrentObjectsVisibility()
-        {
-
-        }
-
         private void ApplyFilters(GameObject building)
         {
             List<ITagFilter> filters = substringTagFilters.Concat(tagFilters).ToList();

--- a/Editor/TagScannerTool.cs
+++ b/Editor/TagScannerTool.cs
@@ -21,7 +21,7 @@ namespace ReupVirtualTwin.editor
         private List<Tag> selectedTags = new List<Tag>();
         private string subStringFilterText = "";
         private float totalWidth;
-        private Dictionary<string, bool> objectsVisibilityState;
+        private List<Dictionary<string, bool>> objectsVisibilityStates = new List<Dictionary<string, bool>>();
 
         [MenuItem("Reup Romulo/Tag Scanner")]
         public static void ShowWindow()
@@ -72,14 +72,20 @@ namespace ReupVirtualTwin.editor
             EditorGUILayout.BeginHorizontal();
                 if (GUILayout.Button("Apply filters"))
                 {
-                    objectsVisibilityState = ObjectVisibilityUtils.GetVisibilityStateOfAllObjects(building, new IdController());
+                    objectsVisibilityStates.Add(ObjectVisibilityUtils.GetVisibilityStateOfAllObjects(building, new IdController()));
                     ApplyFilters(building);
                 }
-                if (GUILayout.Button("Undo filters"))
+                if (GUILayout.Button("Undo filters") && objectsVisibilityStates.Count > 0)
                 {
-                    ObjectVisibilityUtils.ApplyVisibilityState(building, objectsVisibilityState, new IdController());
+                    UndoLastFilters(building);
                 }
             EditorGUILayout.EndHorizontal();
+        }
+
+        private void UndoLastFilters(GameObject building)
+        {
+            Dictionary<string, bool> lastVisibilityState = objectsVisibilityStates.PopLast();
+            ObjectVisibilityUtils.ApplyVisibilityState(building, lastVisibilityState, new IdController());
         }
 
         private void ApplyFilters(GameObject building)

--- a/Editor/TagScannerTool.cs
+++ b/Editor/TagScannerTool.cs
@@ -80,6 +80,11 @@ namespace ReupVirtualTwin.editor
             EditorGUILayout.EndHorizontal();
         }
 
+        private void SaveCurrentObjectsVisibility()
+        {
+
+        }
+
         private void ApplyFilters(GameObject building)
         {
             List<ITagFilter> filters = substringTagFilters.Concat(tagFilters).ToList();

--- a/Editor/TagScannerTool.cs
+++ b/Editor/TagScannerTool.cs
@@ -75,7 +75,7 @@ namespace ReupVirtualTwin.editor
                     objectsVisibilityStates.Add(ObjectVisibilityUtils.GetVisibilityStateOfAllObjects(building, new IdController()));
                     ApplyFilters(building);
                 }
-                if (GUILayout.Button("Undo filters") && objectsVisibilityStates.Count > 0)
+                if (GUILayout.Button("Restore last objects visibility") && objectsVisibilityStates.Count > 0)
                 {
                     UndoLastFilters(building);
                 }

--- a/Editor/TagScannerTool.cs
+++ b/Editor/TagScannerTool.cs
@@ -21,6 +21,7 @@ namespace ReupVirtualTwin.editor
         private List<Tag> selectedTags = new List<Tag>();
         private string subStringFilterText = "";
         private float totalWidth;
+        private Dictionary<string, bool> objectsVisibilityState;
 
         [MenuItem("Reup Romulo/Tag Scanner")]
         public static void ShowWindow()
@@ -71,11 +72,12 @@ namespace ReupVirtualTwin.editor
             EditorGUILayout.BeginHorizontal();
                 if (GUILayout.Button("Apply filters"))
                 {
+                    objectsVisibilityState = ObjectVisibilityUtils.GetVisibilityStateOfAllObjects(building, new IdController());
                     ApplyFilters(building);
                 }
                 if (GUILayout.Button("Undo filters"))
                 {
-                    MisapplyFilters(building);
+                    ObjectVisibilityUtils.ApplyVisibilityState(building, objectsVisibilityState, new IdController());
                 }
             EditorGUILayout.EndHorizontal();
         }
@@ -101,10 +103,6 @@ namespace ReupVirtualTwin.editor
             }
         }
 
-        private void MisapplyFilters(GameObject building)
-        {
-            sceneVisibilityManager.Show(building, true);
-        }
         private void ShowFilters()
         {
             float filterNameWidth = totalWidth * 0.6f;

--- a/Runtime/Helpers/ListUtils.cs
+++ b/Runtime/Helpers/ListUtils.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ReupVirtualTwin.helpers
+{
+    public static class ListUtils
+    {
+        public static T PopLast<T>(this List<T> list)
+        {
+            if (list.Count == 0)
+            {
+                throw new InvalidOperationException("The list is empty.");
+            }
+            T lastItem = list[list.Count - 1];
+            list.RemoveAt(list.Count - 1);
+            return lastItem;
+        }
+    }
+}

--- a/Runtime/Helpers/ListUtils.cs.meta
+++ b/Runtime/Helpers/ListUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6161f5957c068fc4bb018d524e4e8f6d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Helpers/ObjectVisibilityUtils.cs
+++ b/Runtime/Helpers/ObjectVisibilityUtils.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+using ReupVirtualTwin.controllerInterfaces;
+using System.Linq;
+
+namespace ReupVirtualTwin.helpers
+{
+    public static class ObjectVisibilityUtils
+    {
+        static SceneVisibilityManager visibilityManager = SceneVisibilityManager.instance;
+        public static Dictionary<string, bool> GetVisibilityStateOfAllObjects(GameObject obj, IIdGetterController idGetter)
+        {
+            bool visibilityState = !visibilityManager.IsHidden(obj, false);
+            string objId = idGetter.GetIdFromObject(obj);
+            List<Dictionary<string, bool>> childrenStates = new List<Dictionary<string, bool>>();
+            foreach (Transform child in obj.transform)
+            {
+                childrenStates.Add(GetVisibilityStateOfAllObjects(child.gameObject, idGetter));
+            }
+            Dictionary<string, bool> mergedStates = childrenStates.Aggregate(
+                new Dictionary<string, bool>(),
+                (acc, curr) => acc.Union(curr).ToDictionary(pair => pair.Key, pair => pair.Value)
+            );
+            mergedStates.Add(objId, visibilityState);
+            return mergedStates;
+        }
+
+    }
+}

--- a/Runtime/Helpers/ObjectVisibilityUtils.cs
+++ b/Runtime/Helpers/ObjectVisibilityUtils.cs
@@ -28,5 +28,25 @@ namespace ReupVirtualTwin.helpers
             return mergedStates;
         }
 
+        public static void ApplyVisibilityState(GameObject obj, Dictionary<string, bool> visibilityStates, IIdGetterController idGetter)
+        {
+            string objId = idGetter.GetIdFromObject(obj);
+            bool objectVisibility = visibilityStates.GetValueOrDefault(objId);
+            ApplyVisibilityToObject(obj, objectVisibility);
+            foreach (Transform child in obj.transform)
+            {
+                ApplyVisibilityState(child.gameObject, visibilityStates, idGetter);
+            }
+        }
+
+        private static void ApplyVisibilityToObject(GameObject obj, bool visibility)
+        {
+            if (visibility)
+            {
+                visibilityManager.Show(obj, false);
+                return;
+            }
+            visibilityManager.Hide(obj, false);
+        }
     }
 }

--- a/Runtime/Helpers/ObjectVisibilityUtils.cs.meta
+++ b/Runtime/Helpers/ObjectVisibilityUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 99ff78c5223d9cc42b8c1c1282488e40
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/ObjectVisibilityUtilsTest.cs
+++ b/Tests/PlayMode/ObjectVisibilityUtilsTest.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEditor;
+using System.Collections;
+using System.Collections.Generic;
+using ReupVirtualTwin.helpers;
+using ReupVirtualTwin.controllerInterfaces;
+using ReupVirtualTwin.controllers;
+
+namespace ReupVirtualTwinTests.helpers
+{
+    public class ObjectVisibilityUtilsTest
+    {
+        GameObject building;
+        IIdGetterController idController = new IdController();
+
+        [SetUp]
+        public void SetUp()
+        {
+            building = StubObjectTreeCreator.CreateMockBuilding();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            GameObject.Destroy(building);
+        }
+
+        [Test]
+        public void ShouldReturnObjectsVisibilityState_with_all_objects_visible()
+        {
+            Dictionary<string, bool> objectStates = ObjectVisibilityUtils.GetVisibilityStateOfAllObjects(building, idController);
+            foreach(var kvp in objectStates)
+            {
+                Assert.IsTrue(kvp.Value);
+            }
+        }
+    }
+}

--- a/Tests/PlayMode/ObjectVisibilityUtilsTest.cs
+++ b/Tests/PlayMode/ObjectVisibilityUtilsTest.cs
@@ -29,18 +29,16 @@ namespace ReupVirtualTwinTests.helpers
             GameObject.Destroy(building);
         }
 
-        [Test]
-        public void ShouldReturnObjectsVisibilityState_with_all_objects_visible()
+        public void AssertAllObjectsVisible(GameObject parent)
         {
-            Dictionary<string, bool> objectStates = ObjectVisibilityUtils.GetVisibilityStateOfAllObjects(building, idController);
-            foreach(var kvp in objectStates)
+            Dictionary<string, bool> visibilityStates = ObjectVisibilityUtils.GetVisibilityStateOfAllObjects(parent, idController);
+            foreach(var kvp in visibilityStates)
             {
                 Assert.IsTrue(kvp.Value);
             }
         }
 
-        [Test]
-        public void ShouldReturnObjectsVisibilityState_with_some_objects_visible()
+        public List<string> MakeInvisibleSomeObjects()
         {
             List<GameObject> someInvisibleObjects = new List<GameObject>()
             {
@@ -53,8 +51,12 @@ namespace ReupVirtualTwinTests.helpers
             {
                 visibilityManager.Hide(obj, false);
             }
-            Dictionary<string, bool> objectStates = ObjectVisibilityUtils.GetVisibilityStateOfAllObjects(building, idController);
-            foreach(var kvp in objectStates)
+            return invisibleItemsIds;
+        }
+
+        private static void AssertVisibilityStates(List<string> invisibleItemsIds, Dictionary<string, bool> visibilityStates)
+        {
+            foreach (var kvp in visibilityStates)
             {
                 if (invisibleItemsIds.IndexOf(kvp.Key) >= 0)
                 {
@@ -63,6 +65,32 @@ namespace ReupVirtualTwinTests.helpers
                 }
                 Assert.IsTrue(kvp.Value);
             }
+        }
+
+        [Test]
+        public void ShouldReturnObjectsVisibilityState_with_all_objects_visible()
+        {
+            AssertAllObjectsVisible(building);
+        }
+
+        [Test]
+        public void ShouldReturnObjectsVisibilityState_with_some_objects_visible()
+        {
+            List<string> invisibleItemsIds = MakeInvisibleSomeObjects();
+            Dictionary<string, bool> visibilityStates = ObjectVisibilityUtils.GetVisibilityStateOfAllObjects(building, idController);
+            AssertVisibilityStates(invisibleItemsIds, visibilityStates);
+        }
+
+        [Test]
+        public void ShouldApplyVisibility()
+        {
+            List<string> invisibleItemsIds = MakeInvisibleSomeObjects();
+            Dictionary<string, bool> visibilityStatesBefore = ObjectVisibilityUtils.GetVisibilityStateOfAllObjects(building, idController);
+            visibilityManager.Show(building, true);
+            AssertAllObjectsVisible(building);
+            ObjectVisibilityUtils.ApplyVisibilityState(building, visibilityStatesBefore, idController);
+            Dictionary<string, bool> visibilityStatesAfter = ObjectVisibilityUtils.GetVisibilityStateOfAllObjects(building, idController);
+            Assert.AreEqual(visibilityStatesBefore, visibilityStatesAfter);
         }
     }
 }

--- a/Tests/PlayMode/ObjectVisibilityUtilsTest.cs.meta
+++ b/Tests/PlayMode/ObjectVisibilityUtilsTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ce2330813fad2474796f2b1d0567a8fe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/Utils/StubObjectTreeCreator.cs
+++ b/Tests/PlayMode/Utils/StubObjectTreeCreator.cs
@@ -68,7 +68,7 @@ public static class StubObjectTreeCreator
         if (deepChildDepth > 0)
         {
             GameObject deepChild = CreateDeepChainedLineOfObjects(deepChildDepth);
-            deepChild.transform.parent = child1.transform;
+            deepChild.transform.parent = parent.transform;
         }
 
         return parent;


### PR DESCRIPTION
[Reup377](https://macheight-reup.atlassian.net/browse/REUP-377?atlOrigin=eyJpIjoiYTEwZmUzZThiYmM0NGZjMzhjYjE4OWViMjBhNjk2ZTkiLCJwIjoiaiJ9)
As a modeller undoing filters in the tag scanner tool, I don’t want to make all object visible again so that I can return to the state I was in before applying the filters, which is more in line with my typical workflow

AC:

Clicking “undo filters” in the tag scanner tool does not change the visibility of objects other than the filters that were applied

For example, if a user makes all objects except for wall invisible, then filters to “kitchen” in the tag scanner tool, and then clicks the “undo filters” button, they should see just all walls in the scene again

Currently, they see the whole house again including all objects