### PR TITLE
Fix selecting non triangle

### DIFF
--- a/Runtime/Helpers/UvUtils.cs
+++ b/Runtime/Helpers/UvUtils.cs
@@ -116,8 +116,11 @@ namespace ReupVirtualTwin.helpers
             int triangleIndex = 0;
             while (triangleIndex < triangles.Length)
             {
-                if (!ArePointsCollinear(vertices[triangleIndex], vertices[triangleIndex+1], vertices[triangleIndex+2]))
-                {
+                if (!ArePointsCollinear(
+                    vertices[triangles[triangleIndex]],
+                    vertices[triangles[triangleIndex] + 1],
+                    vertices[triangles[triangleIndex] + 2]
+                )){
                     return triangles.AsSpan(triangleIndex, 3).ToArray();
                 }
                 triangleIndex = triangleIndex + 3;

--- a/Runtime/Helpers/UvUtils.cs
+++ b/Runtime/Helpers/UvUtils.cs
@@ -28,7 +28,7 @@ namespace ReupVirtualTwin.helpers
         public static Vector2 GetTextureDimensions(GameObject obj)
         {
             Mesh mesh = obj.GetComponent<MeshFilter>().sharedMesh;
-            UvPointPair[] uvPointPairs = GetSomeUvPointPairs(mesh, 3);
+            UvPointPair[] uvPointPairs = getTriangleWithRespectiveUvs(mesh);
             Func<Vector2, Vector3> uvToSpaceTransformator = CreateUvToSpaceTransformator(uvPointPairs);
             Vector3 uv00ToSpace = uvToSpaceTransformator(new Vector2(0, 0));
             Vector3 uv10ToSpace = uvToSpaceTransformator(new Vector2(1, 0));
@@ -88,26 +88,22 @@ namespace ReupVirtualTwin.helpers
                 return new Vector3((float)x ,(float)y, (float)z);
             };
         }
-        static UvPointPair[] GetSomeUvPointPairs(Mesh mesh, int ammount)
+        static UvPointPair[] getTriangleWithRespectiveUvs(Mesh mesh)
         {
+            int[] triangles = mesh.triangles;
             Vector3[] vertices = mesh.vertices;
             Vector2[] uvs = mesh.uv;
-            List<Vector3> checkedVertices = new List<Vector3>();
-            List<UvPointPair> uv3dPairPoints = new List<UvPointPair>();
-            int i = 0;
-            while (checkedVertices.Count < ammount)
+            int[] choosenTriangle = FirstNonColinearTriangle(triangles, vertices);
+            UvPointPair[] uv3dPairPoints = new UvPointPair[3];
+            for(int i = 0; i < 3; i++)
             {
-                if (!IsNewPointCollinear(checkedVertices, vertices[i]))
+                uv3dPairPoints[i] = new UvPointPair()
                 {
-                    uv3dPairPoints.Add(new UvPointPair {
-                        point = vertices[i],
-                        uv = uvs[i]
-                    });
-                    checkedVertices.Add(vertices[i]);
-                }
-                i++;
+                    uv = uvs[choosenTriangle[i]],
+                    point = vertices[choosenTriangle[i]],
+                };
             }
-            return uv3dPairPoints.ToArray();
+            return uv3dPairPoints;
         }
         public class UvPointPair
         {
@@ -115,21 +111,30 @@ namespace ReupVirtualTwin.helpers
             public Vector3 point;
         }
 
-        private static bool IsNewPointCollinear(List<Vector3> points, Vector3 newPoint)
+        private static int[] FirstNonColinearTriangle(int[] triangles, Vector3[] vertices)
         {
-            if (points.Count <= 1)
+            int triangleIndex = 0;
+            while (triangleIndex < triangles.Length)
             {
-                return false;
+                if (!ArePointsCollinear(vertices[triangleIndex], vertices[triangleIndex+1], vertices[triangleIndex+2]))
+                {
+                    return triangles.AsSpan(triangleIndex, 3).ToArray();
+                }
+                triangleIndex = triangleIndex + 3;
             }
-            Vector3 line = points[0] - points[1];
-            Vector3 newPointVector = points[0] - newPoint;
-            Vector3 crossProduct = Vector3.Cross(line, newPointVector);
+            throw new Exception("no triangle is non collinear");
+        }
+
+        private static bool ArePointsCollinear(Vector3 a, Vector3 b, Vector3 c)
+        {
+            Vector3 line0 = a - b;
+            Vector3 line1 = a - c;
+            Vector3 crossProduct = Vector3.Cross(line0, line1);
             if (crossProduct.magnitude < Mathf.Epsilon)
             {
                 return true;
             }
             return false;
         }
-
     }
 }

--- a/Runtime/Helpers/UvUtils.cs
+++ b/Runtime/Helpers/UvUtils.cs
@@ -2,6 +2,7 @@ using System;
 using UnityEngine;
 using AM = Accord.Math;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ReupVirtualTwin.helpers
 {
@@ -94,16 +95,11 @@ namespace ReupVirtualTwin.helpers
             Vector3[] vertices = mesh.vertices;
             Vector2[] uvs = mesh.uv;
             int[] choosenTriangle = FirstNonColinearTriangle(triangles, vertices);
-            UvPointPair[] uv3dPairPoints = new UvPointPair[3];
-            for(int i = 0; i < 3; i++)
+            return choosenTriangle.Select(triangle => new UvPointPair
             {
-                uv3dPairPoints[i] = new UvPointPair()
-                {
-                    uv = uvs[choosenTriangle[i]],
-                    point = vertices[choosenTriangle[i]],
-                };
-            }
-            return uv3dPairPoints;
+                uv = uvs[triangle],
+                point = vertices[triangle],
+            }).ToArray();
         }
         public class UvPointPair
         {

--- a/Tests/PlayMode/MaterialScalerTest.cs
+++ b/Tests/PlayMode/MaterialScalerTest.cs
@@ -52,7 +52,7 @@ namespace ReupVirtualTwinTests.helpers
         }
 
         [Test]
-        public void ShouldAdjustUVScaleToDimensions_while_avoiding_collinearpoints()
+        public void ShouldAdjustUVScaleToDimensions_while_selecting_non_collinear_triangle()
         {
             GameObject wall = new GameObject();
             MeshRenderer meshRenderer = wall.AddComponent<MeshRenderer>();
@@ -60,15 +60,18 @@ namespace ReupVirtualTwinTests.helpers
             MeshFilter meshFilter = wall.AddComponent<MeshFilter>();
             Mesh mesh = new Mesh();
             mesh.vertices = new Vector3[] {
-                new Vector3(0,0,0), new Vector3(0,0.1f,0), new Vector3(0,0.2f,0), new Vector3(0,0.5f,0), new Vector3(0,1,0), // points in the same line
+                new Vector3(0,0,0), new Vector3(0,0.5f,0), new Vector3(0,1,0), // 3 points in the same line (same 3 points of first triangle)
                 new Vector3(0,1,1),
                 new Vector3(0,0,1),
             };
             mesh.uv = new Vector2[] {
-                new Vector2(0,0), new Vector2(0.1f,0), new Vector2(0.2f,0), new Vector2(0.5f,0), new Vector2(1,0), // points in the same line uvs
-
+                new Vector2(0,0), new Vector2(0.5f,0), new Vector2(1,0), // 3 points in the same line uvs
                 new Vector2(1,1),
                 new Vector2(0,1),
+            };
+            mesh.triangles = new int[] {
+                0, 1, 2,
+                2, 3, 4,
             };
             meshFilter.sharedMesh = mesh;
             materialScaler.AdjustUVScaleToDimensions(wall, new Vector2(2000, 2000));


### PR DESCRIPTION
The recent fix to the material scaling feature ensured that three non-collinear points were selected, but it didn't guarantee that these points belonged to the same triangle. This solution addresses both of these requirements.