### PR TITLE
Reup396 > Reup 403 iphone bug material changes

### DIFF
--- a/Editor/AutoBuildEditor.cs
+++ b/Editor/AutoBuildEditor.cs
@@ -39,6 +39,7 @@ public class AutoBuildEditor : MonoBehaviour
         };
 
 
+        EditorUserBuildSettings.webGLBuildSubtarget = WebGLTextureSubtarget.ASTC;
         BuildReport report = BuildPipeline.BuildPlayer(buildPlayerOptions);
         BuildSummary summary = report.summary;
 

--- a/Runtime/Controllers/ChangeMaterialController.cs
+++ b/Runtime/Controllers/ChangeMaterialController.cs
@@ -44,13 +44,13 @@ namespace ReupVirtualTwin.controllers
             float height = materialChangeInfo["material"]["heightMilimeters"].ToObject<float>();
             Vector2 materialDimensionsInMilimeters = new Vector2(width, height);
             Texture2D texture = await textureDownloader.DownloadTextureFromUrl(materialUrl);
-            Texture2D compressedTexture = textureCompresser.GetASTC12x12CompressedTexture(texture);
-            GameObject.Destroy(texture);
-            if (!compressedTexture)
+            if (!texture)
             {
                 mediator.Notify(ReupEvent.error, $"Error downloading image from {materialUrl}");
                 return;
             }
+            Texture2D compressedTexture = textureCompresser.GetASTC12x12CompressedTexture(texture);
+            GameObject.Destroy(texture);
             List<GameObject> objects = objectRegistry.GetObjectsWithGuids(objectIds);
             Material newMaterial = new Material(Shader.Find("Universal Render Pipeline/Lit"));
             newMaterial.SetTexture("_BaseMap", compressedTexture);

--- a/Runtime/HelperInterfaces/ITextureCompresser.cs
+++ b/Runtime/HelperInterfaces/ITextureCompresser.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace ReupVirtualTwin.helperInterfaces
+{
+    public interface ITextureCompresser
+    {
+        public Texture2D GetASTC12x12CompressedTexture(Texture2D texture);
+    }
+}

--- a/Runtime/HelperInterfaces/ITextureCompresser.cs.meta
+++ b/Runtime/HelperInterfaces/ITextureCompresser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a9ce488e058d535479def61076174d69
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Helpers/TextureCompresser.cs
+++ b/Runtime/Helpers/TextureCompresser.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+using ReupVirtualTwin.helperInterfaces;
+
+namespace ReupVirtualTwin.helpers
+{
+    public class TextureCompresser : ITextureCompresser
+    {
+        public Texture2D GetASTC12x12CompressedTexture(Texture2D texture)
+        {
+            Texture2D compressedTexture = new Texture2D(texture.width, texture.height, TextureFormat.ASTC_12x12, false);
+            byte[] textureBytes = texture.EncodeToPNG();
+            ImageConversion.LoadImage(compressedTexture, textureBytes);
+            return compressedTexture;
+        }
+    }
+}

--- a/Runtime/Helpers/TextureCompresser.cs.meta
+++ b/Runtime/Helpers/TextureCompresser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 49cf28b5a89e40742a0608cdbe2f08f0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/WebRequesters/TextureDownloader.cs
+++ b/Runtime/WebRequesters/TextureDownloader.cs
@@ -14,7 +14,9 @@ namespace ReupVirtualTwin.webRequesters
             WebRequestResult result = await request.SendWebRequestTask();
             if (result.IsSuccess)
             {
-                return DownloadHandlerTexture.GetContent(request);
+                Texture2D texture = DownloadHandlerTexture.GetContent(request);
+                request.downloadHandler.Dispose();
+                return texture;
             }
             return null;
         }


### PR DESCRIPTION
[Reup403](https://macheight-reup.atlassian.net/browse/REUP-403?atlOrigin=eyJpIjoiOWMyZDYyODBiNThiNDc0YTljY2VlMTk4YWY4NmUyMjAiLCJwIjoiaiJ9)

As a developer, I want to compress all textures to ASTC format in unity, so the build consumes less memory in mobile and most desktop browsers.

AC:

When building from the romulo menu, the texture compression format is set to ASTC

downloaded textures are compressed to ASTC, if existent, the default non-compressed created texture is destroyed to release memory

