### PR TITLE
Reup 391 - No disable objects at build time check

### DIFF
--- a/Editor/AutoBuildEditor.cs
+++ b/Editor/AutoBuildEditor.cs
@@ -6,6 +6,8 @@ using ReupVirtualTwin.behaviours;
 using ReupVirtualTwin.helpers;
 using ReupVirtualTwin.controllerInterfaces;
 using ReupVirtualTwin.controllers;
+using System.Collections.Generic;
+using System.Linq;
 
 public class AutoBuildEditor : MonoBehaviour
 {
@@ -23,13 +25,27 @@ public class AutoBuildEditor : MonoBehaviour
             return;
         }
 
-        AddShaders();
+        GameObject building = GetBuilding();
 
-        if (!AddUniqueIDs())
+        if (building == null)
+        {
+            EditorUtility.DisplayDialog("Error", "No building was found", "OK");
+            return;
+        }
+
+        if (!CheckObjectsActiveStatus(building))
+        {
+            return;
+        }
+
+
+        if (!AddUniqueIDs(building))
         {
             EditorUtility.DisplayDialog("Error", "Failed to add unique IDs", "OK");
             return;
         }
+
+        AddShaders();
 
         BuildPlayerOptions buildPlayerOptions = new BuildPlayerOptions
         {
@@ -54,16 +70,16 @@ public class AutoBuildEditor : MonoBehaviour
         
     }
 
-    public static void AddShaders()
+    private static void AddShaders()
     {
         AddShaderUtil.AddAlwaysIncludedShader("sHTiF/HandleShader");
         AddShaderUtil.AddAlwaysIncludedShader("sHTiF/AdvancedHandleShader");
         EditorUtility.DisplayDialog("Success", "Custom shaders configured", "OK");
     }
 
-    public static bool AddUniqueIDs()
+    private static bool AddUniqueIDs(GameObject buildingTree)
     {
-        GameObject building = GetBuilding();
+        GameObject building = buildingTree;
         if (building == null)
         {
             return false;
@@ -106,5 +122,51 @@ public class AutoBuildEditor : MonoBehaviour
         objectInfoController.AssignObjectInfoToTree(building);
         UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(building.scene);
         UnityEditor.SceneManagement.EditorSceneManager.SaveScene(building.scene);
+    }
+
+    private static bool CheckObjectsActiveStatus(GameObject buildingTree)
+    {
+        List<GameObject> disabledObjects = GetDisableObjects(buildingTree);
+        if (disabledObjects.Count > 0)
+        {
+            string message = CreateDisableObjectsMessage(disabledObjects);
+            bool continueBuild = EditorUtility.DisplayDialog(
+                "Disabled Objects Found",
+                message,
+                "Continue",
+                "Cancel"
+            );
+
+            if (!continueBuild)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static List<GameObject> GetDisableObjects(GameObject obj)
+    {
+        List<GameObject> disabledObjects = new List<GameObject>();
+        bool isObjectActive = obj.activeSelf;
+        if (!isObjectActive)
+        {
+            disabledObjects.Add(obj);
+            return disabledObjects;
+        }
+        foreach (Transform child in obj.transform)
+        {
+            disabledObjects.AddRange(GetDisableObjects(child.gameObject));
+        }
+
+        return disabledObjects;
+    }
+
+    private static string CreateDisableObjectsMessage(List<GameObject> disabledObjects)
+    {
+        string disableObjectsNames = string.Join("\n", disabledObjects.Select(obj => obj.name));
+        return $"The following objects are disabled:\n{disableObjectsNames}\n\n" +
+               "This could damage the correct behavior of the model.\n\n" +
+               "Do you want to continue?";
     }
 }

--- a/Editor/AutoBuildEditor.cs
+++ b/Editor/AutoBuildEditor.cs
@@ -35,6 +35,7 @@ public class AutoBuildEditor : MonoBehaviour
 
         if (!CheckObjectsActiveStatus(building))
         {
+            EditorUtility.DisplayDialog("Error", "Build canceled", "OK");
             return;
         }
 

--- a/Editor/AutoBuildEditor.cs
+++ b/Editor/AutoBuildEditor.cs
@@ -132,7 +132,7 @@ public class AutoBuildEditor : MonoBehaviour
         {
             string message = CreateDisableObjectsMessage(disabledObjects);
             bool continueBuild = EditorUtility.DisplayDialog(
-                "Disabled Objects Found",
+                "Warning: Disabled Object(s) Found",
                 message,
                 "Continue",
                 "Cancel"
@@ -165,12 +165,19 @@ public class AutoBuildEditor : MonoBehaviour
 
     private static string CreateDisableObjectsMessage(List<GameObject> disabledObjects)
     {
+        int totalDisabledObjectsCount = disabledObjects.Count;
         var firstTenDisabledObjects = disabledObjects.Take(10).Select(obj => obj.name);
         string disableObjectsNames = string.Join("\n", firstTenDisabledObjects);
-        int totalDisabledObjectsCount = disabledObjects.Count;
-        return $"Total number of disabled objects: {totalDisabledObjectsCount}\n\n" +
-               $"Here is a list of the first 10 disabled objects:\n{disableObjectsNames}\n\n" +
-               "This could damage the correct behavior of the model.\n" +
-               "Do you want to continue?";
+
+        string message = $"{totalDisabledObjectsCount} disabled object(s) found in the scene:\n\n";
+        message += $"{disableObjectsNames}\n";
+
+        if (totalDisabledObjectsCount > 10) {
+            message += $"... and {totalDisabledObjectsCount - 10} more.\n";
+        }
+        message += "\nThis may affect the model's behavior.\n\n";
+        message += "Do you want to continue with the build?";
+
+        return message;
     }
 }

--- a/Editor/AutoBuildEditor.cs
+++ b/Editor/AutoBuildEditor.cs
@@ -165,9 +165,12 @@ public class AutoBuildEditor : MonoBehaviour
 
     private static string CreateDisableObjectsMessage(List<GameObject> disabledObjects)
     {
-        string disableObjectsNames = string.Join("\n", disabledObjects.Select(obj => obj.name));
-        return $"The following objects are disabled:\n{disableObjectsNames}\n\n" +
-               "This could damage the correct behavior of the model.\n\n" +
+        var firstTenDisabledObjects = disabledObjects.Take(10).Select(obj => obj.name);
+        string disableObjectsNames = string.Join("\n", firstTenDisabledObjects);
+        int totalDisabledObjectsCount = disabledObjects.Count;
+        return $"Total number of disabled objects: {totalDisabledObjectsCount}\n\n" +
+               $"Here is a list of the first 10 disabled objects:\n{disableObjectsNames}\n\n" +
+               "This could damage the correct behavior of the model.\n" +
                "Do you want to continue?";
     }
 }


### PR DESCRIPTION
[REUP-391](https://macheight-reup.atlassian.net/browse/REUP-391)

As a modeler, I want to receive a warning when trying to build with disabled objects, so I can catch possible bug reasons sooner.

AC:

When building with disabled objects, a warning appears with the text: “The object <object-name> is disabled, this could damage the correct behavior of the model“.

The warning has the option to stop the build or to accept the risk and continue anyway.