### PR TITLE
Fix scale zeros

### DIFF
--- a/Runtime/Helpers/UvUtils.cs
+++ b/Runtime/Helpers/UvUtils.cs
@@ -145,20 +145,10 @@ namespace ReupVirtualTwin.helpers
             {
                 for (int j = 0; j < columns; j++)
                 {
-                    roundedMatrix[i, j] = RoundToZero(matrix[i, j], threshold);
+                    roundedMatrix[i, j] = Math.Abs(n) > threshold : n : 0;
                 }
             }
             return roundedMatrix;
         }
-
-        public static double RoundToZero(double n, float threshold)
-        {
-            if (Math.Abs(n) > threshold)
-            {
-                return n;
-            }
-            return 0;
-        }
-
     }
 }

--- a/Runtime/Helpers/UvUtils.cs
+++ b/Runtime/Helpers/UvUtils.cs
@@ -145,7 +145,7 @@ namespace ReupVirtualTwin.helpers
             {
                 for (int j = 0; j < columns; j++)
                 {
-                    roundedMatrix[i, j] = Math.Abs(n) > threshold : n : 0;
+                    roundedMatrix[i, j] = Math.Abs(matrix[i,j]) > threshold ? matrix[i,j] : 0;
                 }
             }
             return roundedMatrix;

--- a/Runtime/Helpers/UvUtils.cs
+++ b/Runtime/Helpers/UvUtils.cs
@@ -1,7 +1,6 @@
 using System;
 using UnityEngine;
 using AM = Accord.Math;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace ReupVirtualTwin.helpers
@@ -63,7 +62,8 @@ namespace ReupVirtualTwin.helpers
                 {0, 0, 0, 0, uv2.x, uv2.y, 0, 0, 1, point2.z},
             };
 
-            double[,] reducedMatrix = new AM.ReducedRowEchelonForm(augmentedMatrix).Result;
+            double[,] roundedMatrix = RoundMatrixZeros(augmentedMatrix, 0.001f);
+            double[,] reducedMatrix = new AM.ReducedRowEchelonForm(roundedMatrix).Result;
 
             // supposing the transformation we want to return is of the type:
             // ( a b )   ( u )   ( x0 )     ( x )
@@ -135,5 +135,30 @@ namespace ReupVirtualTwin.helpers
             }
             return false;
         }
+
+        public static double[,] RoundMatrixZeros(double[,] matrix, float threshold)
+        {
+            int rows = matrix.GetLength(0);
+            int columns = matrix.GetLength(1);
+            double[,] roundedMatrix = new double[rows, columns];
+            for (int i = 0; i < rows; i++)
+            {
+                for (int j = 0; j < columns; j++)
+                {
+                    roundedMatrix[i, j] = RoundToZero(matrix[i, j], threshold);
+                }
+            }
+            return roundedMatrix;
+        }
+
+        public static double RoundToZero(double n, float threshold)
+        {
+            if (Math.Abs(n) > threshold)
+            {
+                return n;
+            }
+            return 0;
+        }
+
     }
 }

--- a/Tests/PlayMode/MaterialScalerTest.cs
+++ b/Tests/PlayMode/MaterialScalerTest.cs
@@ -79,5 +79,32 @@ namespace ReupVirtualTwinTests.helpers
             Material material = wall.GetComponent<Renderer>().material;
             AssertUtils.AssertVector2sAreEqual(new Vector2(0.5f, 0.5f), material.mainTextureScale);
         }
+
+        [Test]
+        public void ShouldAdjustUVScaleToDimensions_even_when_infinitesimalArePresentUVOr3DPoints()
+        {
+            GameObject obj = new GameObject();
+            MeshRenderer meshRenderer = obj.AddComponent<MeshRenderer>();
+            meshRenderer.sharedMaterial = new Material(Shader.Find("Universal Render Pipeline/Lit"));;
+            MeshFilter meshFilter = obj.AddComponent<MeshFilter>();
+            Mesh mesh = new Mesh();
+            mesh.vertices = new Vector3[] {
+                new Vector3(-14.1f, 2.9f,  0.12f),
+                new Vector3(2.40000009340928E-15f, 1, 1),
+                new Vector3(1.2999999687846E-10f, 0, 1),
+            };
+            mesh.uv = new Vector2[] {
+                new Vector2(-2.80407665368125E-26f, -2.80407665368125E-26f),
+                new Vector2(-2.80407665368125E-26f, 1.06952011585236f),
+                new Vector2(0.41801193356514f, 1.06952011585236f),
+            };
+            mesh.triangles = new int[] {
+                0, 1, 2,
+            };
+            meshFilter.sharedMesh = mesh;
+            materialScaler.AdjustUVScaleToDimensions(obj, new Vector2(2000, 2000));
+            Material material = obj.GetComponent<Renderer>().material;
+            AssertUtils.AssertVector2sAreEqual(new Vector2(1.196138f, 6.66403f), material.mainTextureScale);
+        }
     }
 }

--- a/Tests/TestUtils/AssertUtils.cs
+++ b/Tests/TestUtils/AssertUtils.cs
@@ -50,7 +50,7 @@ namespace ReupVirtualTwinTests.utils
         public static void AssertVector2sAreEqual(Vector2 expected, Vector2 real)
         {
             float distance = Vector2.Distance(expected, real);
-            Assert.IsTrue(distance < 1e-6);
+            Assert.Less(distance, 1e-6);
         }
 
 


### PR DESCRIPTION
When doing RREF, sometimes having infinitesimal numbers can take the algorithm to numbers greater than MAX_DOUBLE in c#.
So we are just scaling down these numbers to zero before reducing the matrix.