### PR TITLE
Reup392 objects keep highlighted after being selected in mobile

### DIFF
--- a/Runtime/Behaviours/SensedObjectHighlighter.cs
+++ b/Runtime/Behaviours/SensedObjectHighlighter.cs
@@ -38,6 +38,10 @@ namespace ReupVirtualTwin.behaviours
                 return;
             }
             GameObject sensedObject = _objectSensor.Sense();
+            if (sensedObject == highlightedObject && _selectedObjectsManager.IsObjectPartOfSelection(sensedObject))
+            {
+                objectHighlighter.UnhighlightObject(sensedObject);
+            }
             if (sensedObject != highlightedObject)
             {
                 if (highlightedObject != null)


### PR DESCRIPTION
REUP-392(https://macheight-reup.atlassian.net/browse/REUP-392)

Descripción

In the following image:
2 pieces of wall were selected, the one above the window was selected first, then the one below the window. The second piece of wal selected kept the highlight animation that should be visible only when hovering over selectable objects on desktop.

STR:

Select multiple objects on mobile

I would expect to see the 2 objects are selected and have identical highlighting

Instead, I see that the second object selected has the halo effect applied in addition to the outline
![image-20240903-150316](https://github.com/user-attachments/assets/66b16852-f7a2-4dd9-8bec-ae0d528d557b)

