### PR TITLE
create AppProxy shell

### DIFF
--- a/Editor/AppProxy.cs
+++ b/Editor/AppProxy.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+using UnityEditor;
+
+
+namespace ReupVirtualTwin.editor
+{
+    public class AppProxy : EditorWindow
+    {
+        bool viewControls = false;
+        bool dollhouseView;
+        bool firstPersonView;
+        public string[] selStrings = new string[] {"Grid 1", "Grid 2", "Grid 3", "Grid 4"};
+
+
+        [MenuItem("Reup Romulo/App proxy")]
+
+        public static void ShowWindow()
+        {
+            GetWindow<AppProxy>("App proxy");
+        }
+        void OnGUI()
+        {
+            viewControls = EditorGUILayout.Foldout(viewControls, "View controls");
+            if (viewControls)
+            {
+                ViewControls();
+            }
+            EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
+        }
+        void ViewControls()
+        {
+            dollhouseView = EditorGUILayout.Toggle("Dollhouse view", dollhouseView);
+            firstPersonView = EditorGUILayout.Toggle("First-person view", firstPersonView);
+        }
+    }
+}

--- a/Editor/AppProxy.cs.meta
+++ b/Editor/AppProxy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 253820c2b6d756f479bd6dec78ee5a4f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
[Reup407](https://macheight-reup.atlassian.net/browse/REUP-407?atlOrigin=eyJpIjoiOTlmMGE5ODM0MmNjNGViODg2YjA3MDZiYmI1MjJlMGIiLCJwIjoiaiJ9)

As a modeler, I want to be able to mimic the views plugin when running the model in unity, so I don’t have to export a model to test the feature.

AC:

When running the model in unity, exist a mechanism to mimic the actions described in [Reup-405](https://macheight-reup.atlassian.net/browse/REUP-405)

Just the tool with buttons to use is necessary, the button’s behaviors will be added as those features are developed.

Notes:

Suggestions: 

probably a new game object will be created to handle all view option actions. We could put some buttons on that object inspector window that send the same actions the plugin would send from angular

another option would be to make a separate tool with those 4 buttons, but not attached to any game object. (I personally think this is more organized than putting those controls in a buried who knows where object)