### PR TITLE
REUP 390 - remove errors when blue bubbles and room spaces are not placed in the scene

### DIFF
--- a/Runtime/Helpers/Selectors/ObjectSelectors/MaterialSelectionSelector.cs
+++ b/Runtime/Helpers/Selectors/ObjectSelectors/MaterialSelectionSelector.cs
@@ -7,7 +7,7 @@ namespace ReupVirtualTwin.helpers
     {
         protected override GameObject GetSelectedObjectFromHitObject(GameObject obj)
         {
-            if (obj.CompareTag(TagsEnum.materialSelection))
+            if (obj.tag == TagsEnum.materialSelection)
             {
                 return obj;
             }

--- a/Runtime/Helpers/Selectors/ObjectSelectors/TriggerSelector.cs
+++ b/Runtime/Helpers/Selectors/ObjectSelectors/TriggerSelector.cs
@@ -7,7 +7,7 @@ namespace ReupVirtualTwin.helpers
     {
         protected override GameObject GetSelectedObjectFromHitObject(GameObject obj)
         {
-            if (obj.CompareTag(TagsEnum.trigger))
+            if (obj.tag == TagsEnum.trigger)
             {
                 return obj;
             }

--- a/Runtime/Helpers/Selectors/RayCastHitSelector/MoveToHitSelector.cs
+++ b/Runtime/Helpers/Selectors/RayCastHitSelector/MoveToHitSelector.cs
@@ -1,23 +1,21 @@
 using UnityEngine;
 using ReupVirtualTwin.enums;
+using System.Collections.Generic;
 
 namespace ReupVirtualTwin.helpers
 {
     public class MoveToHitSelector : RayCastHitSelector
     {
-        private string[] ignoreTags = new string[]
+        private HashSet<string> ignoreTags = new HashSet<string>
         {
             TagsEnum.trigger,
-            TagsEnum.materialSelection,
+            TagsEnum.materialSelection
         };
         protected override GameObject GetSelectedObjectFromHitObject(GameObject obj)
         {
-            foreach(string tag in ignoreTags)
+            if (ignoreTags.Contains(obj.tag))
             {
-                if (obj.CompareTag(tag))
-                {
-                    return null;
-                }
+                return null;
             }
             return obj;
         }


### PR DESCRIPTION
[REUP-390](https://macheight-reup.atlassian.net/browse/REUP-390)

As a modeler, I don’t want to have any error when I decide not to place any space selector or any old material picker (blue bubble), so it’s easier to debug real errors.

If no blue bubble is placed, no error about the trigger tag not being defined appears.

if no space selector is placed, no error about the space tag not being defined appears.
