### PR TITLE
Reup 419 - Check for multiple cameras at build time

### DIFF
--- a/Editor/AutoBuildEditor.cs
+++ b/Editor/AutoBuildEditor.cs
@@ -25,6 +25,17 @@ public class AutoBuildEditor : MonoBehaviour
             return;
         }
 
+        if (!CheckOneCameraInScene())
+        {
+            EditorUtility.DisplayDialog(
+                "Error", 
+                "More than one camera found in the scene\n\n" +
+                "Please erase any additional cameras outside the Reup Prefab", 
+                "OK"
+            );
+            return;
+        }
+
         GameObject building = GetBuilding();
 
         if (building == null)
@@ -172,5 +183,17 @@ public class AutoBuildEditor : MonoBehaviour
                $"Here is a list of the first 10 disabled objects:\n{disableObjectsNames}\n\n" +
                "This could damage the correct behavior of the model.\n" +
                "Do you want to continue?";
+    }
+
+    private static bool CheckOneCameraInScene()
+    {
+        int cameraCount = Camera.allCamerasCount;
+
+        if (cameraCount > 1)
+        {
+            Debug.LogWarning("More than one camera found in the scene.");
+            return false;
+        }
+        return true;
     }
 }

--- a/Editor/AutoBuildEditor.cs
+++ b/Editor/AutoBuildEditor.cs
@@ -25,7 +25,7 @@ public class AutoBuildEditor : MonoBehaviour
             return;
         }
 
-        if (!CheckOneCameraInScene())
+        if (Camera.allCamerasCount > 1)
         {
             EditorUtility.DisplayDialog(
                 "Error", 
@@ -183,17 +183,5 @@ public class AutoBuildEditor : MonoBehaviour
                $"Here is a list of the first 10 disabled objects:\n{disableObjectsNames}\n\n" +
                "This could damage the correct behavior of the model.\n" +
                "Do you want to continue?";
-    }
-
-    private static bool CheckOneCameraInScene()
-    {
-        int cameraCount = Camera.allCamerasCount;
-
-        if (cameraCount > 1)
-        {
-            Debug.LogWarning("More than one camera found in the scene.");
-            return false;
-        }
-        return true;
     }
 }


### PR DESCRIPTION
[Reup-419](https://macheight-reup.atlassian.net/browse/REUP-419)

As a developer, I want to fail any build attempt with more than one main camera in unity, so we can avoid bugs in the bases for having multiple cameras

AC:

If more than one main camera is present at build time, the build is canceled and an error is shown to the modeler clearly indicating the reason for the error