### PR TITLE
Reup402 free texture memory

### DIFF
--- a/Assets/Quickstart/Reup.prefab
+++ b/Assets/Quickstart/Reup.prefab
@@ -268,7 +268,6 @@ Transform:
   - {fileID: 321911388155495687}
   - {fileID: 1328519742650971401}
   - {fileID: 842751329097319180}
-  - {fileID: 2723610775828279206}
   - {fileID: 690887863738009567}
   - {fileID: 4437606995447908561}
   m_Father: {fileID: 680367125633172352}
@@ -300,17 +299,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   insertPositionLocation: {fileID: 6878658961563752214}
-  editModeManager: {fileID: 3162418224126025097}
-  selectedObjectsManager: {fileID: 3225898039182815318}
-  transformObjectsManager: {fileID: 1552584488162308612}
-  deleteObjectsManager: {fileID: 4137723397174542886}
-  changeColorManager: {fileID: 8846973471203599374}
-  modelInfoManager: {fileID: 6552919786407009463}
+  editModeManager: {fileID: 5733580648411075496}
+  selectedObjectsManager: {fileID: 9138131387677620797}
+  transformObjectsManager: {fileID: 7238550132328462757}
+  deleteObjectsManager: {fileID: 760658980525887724}
+  changeColorManager: {fileID: 2078422153407114265}
+  modelInfoManager: {fileID: 7334026899500025913}
   character: {fileID: 1798908995094544088}
   fpvCamera: {fileID: 8060287538316763243}
   dhvCamera: {fileID: 2401207048260687702}
   viewModeManager: {fileID: 3904143813462744938}
   texturesManager: {fileID: 7203003387684823839}
+  characterRotationManager: {fileID: 9154797268538216174}
+  objectRegistry: {fileID: 2043244847565700485}
 --- !u!114 &6350977991642200349
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1067,6 +1068,7 @@ Transform:
   - {fileID: 680367125633172352}
   - {fileID: 3377086067190760999}
   - {fileID: 2471139282865268767}
+  - {fileID: 2723610775828279206}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2920257305175609590
@@ -2108,12 +2110,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6878658961563752214}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 4925350699689954789}
+  m_Father: {fileID: 1178337683573207492}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1557426382952898549
 MonoBehaviour:

--- a/Assets/Quickstart/Reup.prefab
+++ b/Assets/Quickstart/Reup.prefab
@@ -113,6 +113,7 @@ Transform:
   - {fileID: 391374155542431438}
   - {fileID: 4921429640420800414}
   - {fileID: 8698737246674232654}
+  - {fileID: 408726682764161858}
   m_Father: {fileID: 1178337683573207492}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &780637907895890256
@@ -319,6 +320,50 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c7445fe7907c9154198057fe7ebda33e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1137888274583213051
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 408726682764161858}
+  - component: {fileID: 7203003387684823839}
+  m_Layer: 0
+  m_Name: TexturesManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &408726682764161858
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1137888274583213051}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 680367125633172352}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7203003387684823839
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1137888274583213051}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d1fda82499d515f42afbe8cea281b008, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1259473726147856764

--- a/Assets/Quickstart/Reup.prefab
+++ b/Assets/Quickstart/Reup.prefab
@@ -332,6 +332,7 @@ GameObject:
   m_Component:
   - component: {fileID: 408726682764161858}
   - component: {fileID: 7203003387684823839}
+  - component: {fileID: 7954376064475650718}
   m_Layer: 0
   m_Name: TexturesManager
   m_TagString: Untagged
@@ -364,6 +365,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d1fda82499d515f42afbe8cea281b008, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &7954376064475650718
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1137888274583213051}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1ee2102d1eb6ce6418a2cb62d0922fdc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1259473726147856764
@@ -1668,8 +1681,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5684383910040997618}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.42261827, y: 0, z: 0, w: 0.9063079}
-  m_LocalPosition: {x: 0, y: 42.673183, z: -26.930277}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Quickstart/Reup.prefab
+++ b/Assets/Quickstart/Reup.prefab
@@ -310,6 +310,7 @@ MonoBehaviour:
   fpvCamera: {fileID: 8060287538316763243}
   dhvCamera: {fileID: 2401207048260687702}
   viewModeManager: {fileID: 3904143813462744938}
+  texturesManager: {fileID: 7203003387684823839}
 --- !u!114 &6350977991642200349
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1681,8 +1682,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5684383910040997618}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0.42261827, y: 0, z: 0, w: 0.9063079}
+  m_LocalPosition: {x: 0, y: 42.673183, z: -26.930277}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Editor/SetUpBuildingEditor.cs
+++ b/Editor/SetUpBuildingEditor.cs
@@ -31,14 +31,17 @@ namespace ReupVirtualTwin.editor
                 if (GUILayout.Button("Add Ids to objects"))
                 {
                     setUpBuilding.AssignIdsAndObjectInfoToBuilding();
+                    Debug.Log("Ids and object info added to tree");
                 }
                 if (GUILayout.Button("Remove Ids from objects"))
                 {
                     setUpBuilding.RemoveIdsAndObjectInfoFromBuilding();
+                    Debug.Log("Ids and object info removed from tree");
                 }
                 if (GUILayout.Button("Reset Ids from objects"))
                 {
                     setUpBuilding.ResetIdsOfBuilding();
+                    Debug.Log("Ids and object info reseted from tree");
                 }
             }
             showTagsOptions = EditorGUILayout.Foldout(showTagsOptions, "Objects Tags");
@@ -51,6 +54,7 @@ namespace ReupVirtualTwin.editor
                 if (GUILayout.Button("Add tag system to objects"))
                 {
                     setUpBuilding.AddTagSystemToBuildingObjects();
+                    Debug.Log("tags script added to tree");
                 }
             }
         }

--- a/Runtime/Behaviours/SetupBuilding.cs
+++ b/Runtime/Behaviours/SetupBuilding.cs
@@ -6,7 +6,7 @@ using ReupVirtualTwin.controllerInterfaces;
 
 namespace ReupVirtualTwin.behaviours
 {
-    public class SetupBuilding : MonoBehaviour , ISetUpBuilding, IOnBuildingSetup, IBuildingGetterSetter
+    public class SetupBuilding : MonoBehaviour, ISetUpBuilding, IOnBuildingSetup, IBuildingGetterSetter
     {
 
         [SerializeField]
@@ -58,25 +58,21 @@ namespace ReupVirtualTwin.behaviours
         {
             _idAssignerController.AssignIdsToTree(building);
             _objectInfoController.AssignObjectInfoToTree(building);
-            Debug.Log("Ids and object info added to tree");
         }
         public void RemoveIdsAndObjectInfoFromBuilding()
         {
             _idAssignerController.RemoveIdsFromTree(building);
             _objectInfoController.RemoveObjectInfoFromTree(building);
-            Debug.Log("Ids and object info removed from tree");
         }
         public void ResetIdsOfBuilding()
         {
             RemoveIdsAndObjectInfoFromBuilding();
             AssignIdsAndObjectInfoToBuilding();
-            Debug.Log("Ids and object info reseted from tree");
         }
 
         public void AddTagSystemToBuildingObjects()
         {
             _tagSystemController.AssignTagSystemToTree(building);
-            Debug.Log("tags script added to tree");
         }
     }
 }

--- a/Runtime/Controllers/ChangeMaterialController.cs
+++ b/Runtime/Controllers/ChangeMaterialController.cs
@@ -12,6 +12,7 @@ using ReupVirtualTwin.dataSchemas;
 using Newtonsoft.Json.Linq;
 using ReupVirtualTwin.helperInterfaces;
 using Newtonsoft.Json.Schema;
+using ReupVirtualTwin.managerInterfaces;
 
 namespace ReupVirtualTwin.controllers
 {
@@ -21,10 +22,12 @@ namespace ReupVirtualTwin.controllers
         public ITextureCompresser textureCompresser = new TextureCompresser();
         readonly ITextureDownloader textureDownloader;
         readonly IObjectRegistry objectRegistry;
-        public ChangeMaterialController(ITextureDownloader textureDownloader, IObjectRegistry objectRegistry)
+        readonly ITexturesManager texturesManager;
+        public ChangeMaterialController(ITextureDownloader textureDownloader, IObjectRegistry objectRegistry, ITexturesManager texturesManager)
         {
             this.textureDownloader = textureDownloader;
             this.objectRegistry = objectRegistry;
+            this.texturesManager = texturesManager;
         }
 
         public async Task<TaskResult> ChangeObjectMaterial(JObject materialChangeInfo)
@@ -58,7 +61,7 @@ namespace ReupVirtualTwin.controllers
             {
                 if (objects[i].GetComponent<Renderer>() != null)
                 {
-                    objects[i].GetComponent<Renderer>().material = newMaterial;
+                    texturesManager.ApplyMaterialToObject(objects[i], newMaterial);
                     objects[i].GetComponent<IObjectInfo>().materialWasChanged = true;
                     ObjectMetaDataUtils.AssignMaterialIdMetaDataToObject(objects[i], materialChangeInfo["material"]["id"].ToObject<int>());
                     materialScaler.AdjustUVScaleToDimensions(objects[i], materialDimensionsInMillimeters);

--- a/Runtime/Controllers/OriginalSceneController.cs
+++ b/Runtime/Controllers/OriginalSceneController.cs
@@ -4,15 +4,18 @@ using UnityEngine;
 
 using ReupVirtualTwin.controllerInterfaces;
 using ReupVirtualTwin.modelInterfaces;
+using ReupVirtualTwin.managerInterfaces;
 
 namespace ReupVirtualTwin.controllers
 {
     public class OriginalSceneController : IOriginalSceneController
     {
         IObjectRegistry registry;
-        public OriginalSceneController(IObjectRegistry registry)
+        readonly ITexturesManager texturesManager;
+        public OriginalSceneController(IObjectRegistry registry, ITexturesManager texturesManager)
         {
             this.registry = registry;
+            this.texturesManager = texturesManager;
         }
         public void RestoreOriginalScene()
         {
@@ -24,7 +27,7 @@ namespace ReupVirtualTwin.controllers
                 MeshRenderer meshRenderer = obj.GetComponent<MeshRenderer>();
                 if (meshRenderer != null && objectInfo.materialWasChanged)
                 {
-                    meshRenderer.material = originalMaterial;
+                    texturesManager.ApplyProtectedMaterialToObject(obj, originalMaterial);
                     objectInfo.materialWasRestored = true;
                 }
             }

--- a/Runtime/DependencyInjectors/EditMediatorDependecyInjector.cs
+++ b/Runtime/DependencyInjectors/EditMediatorDependecyInjector.cs
@@ -36,10 +36,12 @@ namespace ReupVirtualTwin.dependencyInjectors
         GameObject dhvCamera;
         [SerializeField]
         ViewModeManager viewModeManager;
+        [SerializeField]
+        TexturesManager texturesManager;
 
         private void Awake()
         {
-            if(!insertPositionLocation ||
+            if (!insertPositionLocation ||
                 !editModeManager ||
                 !selectedObjectsManager ||
                 !transformObjectsManager ||
@@ -48,6 +50,7 @@ namespace ReupVirtualTwin.dependencyInjectors
                 !modelInfoManager ||
                 !fpvCamera ||
                 !dhvCamera ||
+                !texturesManager ||
                 !character)
             {
                 throw new System.Exception("Some dependencies are missing");
@@ -62,7 +65,7 @@ namespace ReupVirtualTwin.dependencyInjectors
             editMediator.changeColorManager = changeColorManager.GetComponent<IChangeColorManager>();
             editMediator.modelInfoManager = modelInfoManager.GetComponent<IModelInfoManager>();
             IWebMessagesSender webMessageSender = GetComponent<IWebMessagesSender>();
-            if (webMessageSender == null )
+            if (webMessageSender == null)
             {
                 throw new System.Exception("WebMessageSender not found to inject to edit mediator");
             }
@@ -78,9 +81,10 @@ namespace ReupVirtualTwin.dependencyInjectors
             );
             editMediator.changeMaterialController = new ChangeMaterialController(
                 new TextureDownloader(),
-                registry
+                registry,
+                texturesManager
             );
-            editMediator.originalSceneController = new OriginalSceneController(registry);
+            editMediator.originalSceneController = new OriginalSceneController(registry, texturesManager);
             editMediator.viewModeManager = viewModeManager;
         }
     }

--- a/Runtime/DependencyInjectors/EditMediatorDependecyInjector.cs
+++ b/Runtime/DependencyInjectors/EditMediatorDependecyInjector.cs
@@ -7,37 +7,28 @@ using ReupVirtualTwin.managers;
 using ReupVirtualTwin.controllers;
 using ReupVirtualTwin.modelInterfaces;
 using ReupVirtualTwin.webRequesters;
+using ReupVirtualTwin.models;
 
 namespace ReupVirtualTwin.dependencyInjectors
 {
     [RequireComponent(typeof(EditMediator))]
     public class EditMediatorDependecyInjector : MonoBehaviour
     {
-        [SerializeField]
-        GameObject insertPositionLocation;
         EditMediator editMediator;
-        [SerializeField]
-        GameObject editModeManager;
-        [SerializeField]
-        GameObject selectedObjectsManager;
-        [SerializeField]
-        GameObject transformObjectsManager;
-        [SerializeField]
-        GameObject deleteObjectsManager;
-        [SerializeField]
-        GameObject changeColorManager;
-        [SerializeField]
-        GameObject modelInfoManager;
-        [SerializeField]
-        GameObject character;
-        [SerializeField]
-        GameObject fpvCamera;
-        [SerializeField]
-        GameObject dhvCamera;
-        [SerializeField]
-        ViewModeManager viewModeManager;
-        [SerializeField]
-        TexturesManager texturesManager;
+        [SerializeField] GameObject insertPositionLocation;
+        [SerializeField] EditModeManager editModeManager;
+        [SerializeField] SelectedObjectsManager selectedObjectsManager;
+        [SerializeField] TransformObjectsManager transformObjectsManager;
+        [SerializeField] DeleteObjectsManager deleteObjectsManager;
+        [SerializeField] ChangeColorManager changeColorManager;
+        [SerializeField] ModelInfoManager modelInfoManager;
+        [SerializeField] GameObject character;
+        [SerializeField] GameObject fpvCamera;
+        [SerializeField] GameObject dhvCamera;
+        [SerializeField] ViewModeManager viewModeManager;
+        [SerializeField] TexturesManager texturesManager;
+        [SerializeField] CharacterRotationManager characterRotationManager;
+        [SerializeField] ObjectRegistry objectRegistry;
 
         private void Awake()
         {
@@ -56,14 +47,13 @@ namespace ReupVirtualTwin.dependencyInjectors
                 throw new System.Exception("Some dependencies are missing");
             }
             editMediator = GetComponent<EditMediator>();
-            ICharacterRotationManager characterRotationManager = ObjectFinder.FindCharacter().GetComponent<ICharacterRotationManager>();
             editMediator.characterRotationManager = characterRotationManager;
-            editMediator.editModeManager = editModeManager.GetComponent<IEditModeManager>();
-            editMediator.selectedObjectsManager = selectedObjectsManager.GetComponent<ISelectedObjectsManager>();
-            editMediator.transformObjectsManager = transformObjectsManager.GetComponent<ITransformObjectsManager>();
-            editMediator.deleteObjectsManager = deleteObjectsManager.GetComponent<IDeleteObjectsManager>();
-            editMediator.changeColorManager = changeColorManager.GetComponent<IChangeColorManager>();
-            editMediator.modelInfoManager = modelInfoManager.GetComponent<IModelInfoManager>();
+            editMediator.editModeManager = editModeManager;
+            editMediator.selectedObjectsManager = selectedObjectsManager;
+            editMediator.transformObjectsManager = transformObjectsManager;
+            editMediator.deleteObjectsManager = deleteObjectsManager;
+            editMediator.changeColorManager = changeColorManager;
+            editMediator.modelInfoManager = modelInfoManager;
             IWebMessagesSender webMessageSender = GetComponent<IWebMessagesSender>();
             if (webMessageSender == null)
             {
@@ -71,8 +61,7 @@ namespace ReupVirtualTwin.dependencyInjectors
             }
             editMediator.webMessageSender = webMessageSender;
             editMediator.objectMapper = new ObjectMapper(new TagsController(), new IdController());
-            IObjectRegistry registry = ObjectFinder.FindObjectRegistry().GetComponent<IObjectRegistry>();
-            editMediator.registry = registry;
+            editMediator.registry = objectRegistry;
             editMediator.insertObjectsController = new InsertObjectController(
                 editMediator,
                 new MeshDownloader(),
@@ -81,10 +70,10 @@ namespace ReupVirtualTwin.dependencyInjectors
             );
             editMediator.changeMaterialController = new ChangeMaterialController(
                 new TextureDownloader(),
-                registry,
+                objectRegistry,
                 texturesManager
             );
-            editMediator.originalSceneController = new OriginalSceneController(registry, texturesManager);
+            editMediator.originalSceneController = new OriginalSceneController(objectRegistry, texturesManager);
             editMediator.viewModeManager = viewModeManager;
         }
     }

--- a/Runtime/DependencyInjectors/TexturesManagerDependencyInjector.cs
+++ b/Runtime/DependencyInjectors/TexturesManagerDependencyInjector.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using ReupVirtualTwin.controllers;
+using ReupVirtualTwin.managers;
+using UnityEngine;
+
+namespace ReupVirtualTwin.dependencyInjectors
+{
+    public class TexturesManagerDependencyInjector : MonoBehaviour
+    {
+        private void Awake()
+        {
+            TexturesManager texturesManager = GetComponent<TexturesManager>();
+            texturesManager.idGetterController = new IdController();
+        }
+    }
+
+}

--- a/Runtime/DependencyInjectors/TexturesManagerDependencyInjector.cs.meta
+++ b/Runtime/DependencyInjectors/TexturesManagerDependencyInjector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ee2102d1eb6ce6418a2cb62d0922fdc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/ManagerInterfaces/ITexturesManager.cs
+++ b/Runtime/ManagerInterfaces/ITexturesManager.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ReupVirtualTwin.managerInterfaces
+{
+    public interface ITexturesManager
+    {
+        public void ApplyMaterialToObject(GameObject obj, Material material);
+    }
+}

--- a/Runtime/ManagerInterfaces/ITexturesManager.cs
+++ b/Runtime/ManagerInterfaces/ITexturesManager.cs
@@ -7,5 +7,6 @@ namespace ReupVirtualTwin.managerInterfaces
     public interface ITexturesManager
     {
         public void ApplyMaterialToObject(GameObject obj, Material material);
+        public void ApplyProtectedMaterialToObject(GameObject obj, Material material);
     }
 }

--- a/Runtime/ManagerInterfaces/ITexturesManager.cs.meta
+++ b/Runtime/ManagerInterfaces/ITexturesManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a0983bac802b99a4d9d6a26b6754cfbb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Managers/TexturesManager.cs
+++ b/Runtime/Managers/TexturesManager.cs
@@ -9,7 +9,10 @@ namespace ReupVirtualTwin.managers
     {
         public void ApplyMaterialToObject(GameObject obj, Material material)
         {
-            obj.GetComponent<Renderer>().material = material;
+            Renderer renderer = obj.GetComponent<Renderer>();
+            Texture oldTexture = renderer.material.GetTexture("_BaseMap");
+            renderer.material = material;
+            Destroy(oldTexture);
         }
     }
 

--- a/Runtime/Managers/TexturesManager.cs
+++ b/Runtime/Managers/TexturesManager.cs
@@ -1,0 +1,16 @@
+using System.Collections;
+using System.Collections.Generic;
+using ReupVirtualTwin.managerInterfaces;
+using UnityEngine;
+
+namespace ReupVirtualTwin.managers
+{
+    public class TexturesManager : MonoBehaviour, ITexturesManager
+    {
+        public void ApplyMaterialToObject(GameObject obj, Material material)
+        {
+            obj.GetComponent<Renderer>().material = material;
+        }
+    }
+
+}

--- a/Runtime/Managers/TexturesManager.cs
+++ b/Runtime/Managers/TexturesManager.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using ReupVirtualTwin.controllerInterfaces;
 using ReupVirtualTwin.managerInterfaces;
 using UnityEngine;
 
@@ -7,12 +8,47 @@ namespace ReupVirtualTwin.managers
 {
     public class TexturesManager : MonoBehaviour, ITexturesManager
     {
+        public IIdGetterController idGetterController { set; get; }
+        Dictionary<string, Texture> objectIdsToTexturesRecord;
+        Dictionary<Texture, HashSet<string>> texturesToObjectIdsRecord;
+
+        private void Awake()
+        {
+            objectIdsToTexturesRecord = new Dictionary<string, Texture>();
+            texturesToObjectIdsRecord = new Dictionary<Texture, HashSet<string>>();
+        }
+
         public void ApplyMaterialToObject(GameObject obj, Material material)
         {
             Renderer renderer = obj.GetComponent<Renderer>();
-            Texture oldTexture = renderer.material.GetTexture("_BaseMap");
             renderer.material = material;
-            Destroy(oldTexture);
+            Texture newTexture = material.GetTexture("_BaseMap");
+            UpdateRecords(obj, newTexture);
+        }
+
+        void UpdateRecords(GameObject obj, Texture newTexture)
+        {
+            string objId = idGetterController.GetIdFromObject(obj);
+            Texture oldTexture = objectIdsToTexturesRecord.GetValueOrDefault(objId);
+            UpdateTextureRecords(objId, oldTexture, newTexture);
+            objectIdsToTexturesRecord[objId] = newTexture;
+        }
+        void UpdateTextureRecords(string objId, Texture oldTexture, Texture newTexture)
+        {
+            if (oldTexture != null && texturesToObjectIdsRecord[oldTexture] != null)
+            {
+                texturesToObjectIdsRecord[oldTexture].Remove(objId);
+                if (texturesToObjectIdsRecord[oldTexture].Count == 0)
+                {
+                    Destroy(oldTexture);
+                    texturesToObjectIdsRecord.Remove(oldTexture);
+                }
+            }
+            if (!texturesToObjectIdsRecord.ContainsKey(newTexture))
+            {
+                texturesToObjectIdsRecord[newTexture] = new HashSet<string>();
+            }
+            texturesToObjectIdsRecord[newTexture].Add(objId);
         }
     }
 

--- a/Runtime/Managers/TexturesManager.cs.meta
+++ b/Runtime/Managers/TexturesManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d1fda82499d515f42afbe8cea281b008
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/ObjectRegistryTests.cs
+++ b/Tests/PlayMode/ObjectRegistryTests.cs
@@ -15,12 +15,14 @@ namespace ReupVirtualTwinTests.Registry
         IObjectRegistry objectRegistry;
         GameObject testObj0;
         GameObject testObj1;
+        int originalObjectsCount;
 
         [UnitySetUp]
         public IEnumerator SetUp()
         {
             sceneObjects = ReupSceneInstantiator.InstantiateScene();
             objectRegistry = sceneObjects.objectRegistry;
+            originalObjectsCount = objectRegistry.GetObjectsCount();
             yield return null;
         }
 
@@ -43,7 +45,7 @@ namespace ReupVirtualTwinTests.Registry
             objectRegistry.AddObject(testObj0);
             var retrievedObj = objectRegistry.GetObjectWithGuid(id);
             Assert.AreEqual(testObj0, retrievedObj);
-            Assert.AreEqual(1, objectRegistry.GetObjectsCount());
+            Assert.AreEqual(originalObjectsCount + 1, objectRegistry.GetObjectsCount());
             yield return null;
         }
 
@@ -73,7 +75,7 @@ namespace ReupVirtualTwinTests.Registry
             objectRegistry.AddObject(testObj0);
             var retrievedObj0 = objectRegistry.GetObjectWithGuid(id0);
             Assert.AreEqual(testObj0, retrievedObj0);
-            Assert.AreEqual(1, objectRegistry.GetObjectsCount());
+            Assert.AreEqual(originalObjectsCount + 1, objectRegistry.GetObjectsCount());
             yield return null;
             testObj1 = new GameObject("testObj1");
             IUniqueIdentifier uniqueIdentifier1 = testObj1.AddComponent<UniqueId>();
@@ -81,7 +83,7 @@ namespace ReupVirtualTwinTests.Registry
             objectRegistry.AddObject(testObj1);
             var retrievedObj1 = objectRegistry.GetObjectWithGuid(id1);
             Assert.AreEqual(testObj1, retrievedObj1);
-            Assert.AreEqual(2, objectRegistry.GetObjectsCount());
+            Assert.AreEqual(originalObjectsCount + 2, objectRegistry.GetObjectsCount());
             yield return null;
         }
 
@@ -94,11 +96,11 @@ namespace ReupVirtualTwinTests.Registry
             objectRegistry.AddObject(testObj0);
             var retrievedObj = objectRegistry.GetObjectWithGuid(id);
             Assert.AreEqual(testObj0, retrievedObj);
-            Assert.AreEqual(1, objectRegistry.GetObjectsCount());
+            Assert.AreEqual(originalObjectsCount + 1, objectRegistry.GetObjectsCount());
             yield return null;
 
             objectRegistry.RemoveObject(testObj0);
-            Assert.AreEqual(0, objectRegistry.GetObjectsCount());
+            Assert.AreEqual(originalObjectsCount, objectRegistry.GetObjectsCount());
             Assert.IsNull(objectRegistry.GetObjectWithGuid(id));
             yield return null;
         }
@@ -113,7 +115,7 @@ namespace ReupVirtualTwinTests.Registry
             IUniqueIdentifier uniqueIdentifier1 = testObj1.AddComponent<UniqueId>();
             uniqueIdentifier1.GenerateId();
             objectRegistry.AddObject(testObj1);
-            Assert.AreEqual(2, objectRegistry.GetObjectsCount());
+            Assert.AreEqual(originalObjectsCount + 2, objectRegistry.GetObjectsCount());
             yield return null;
             objectRegistry.ClearRegistry();
             Assert.AreEqual(0, objectRegistry.GetObjectsCount());
@@ -126,10 +128,10 @@ namespace ReupVirtualTwinTests.Registry
             testObj0.AddComponent<UniqueId>().GenerateId();
             testObj1 = new GameObject("testObj1");
             objectRegistry.AddObject(testObj0);
-            Assert.AreEqual(1, objectRegistry.GetObjectsCount());
+            Assert.AreEqual(originalObjectsCount + 1, objectRegistry.GetObjectsCount());
             yield return null;
             objectRegistry.RemoveObject(testObj1);
-            Assert.AreEqual(1, objectRegistry.GetObjectsCount());
+            Assert.AreEqual(originalObjectsCount + 1, objectRegistry.GetObjectsCount());
             yield return null;
         }
 

--- a/Tests/PlayMode/RegisteredIdentifierTest.cs
+++ b/Tests/PlayMode/RegisteredIdentifierTest.cs
@@ -64,13 +64,14 @@ namespace ReupVirtualTwinTests.Registry
         {
             string currentId = testObj.GetComponent<RegisteredIdentifier>().getId();
             Assert.AreEqual(testObj, objectRegistry.GetObjectWithGuid(currentId));
-            Assert.AreEqual(1, objectRegistry.GetObjectsCount());
+            int objectsInRegistryBefore = objectRegistry.GetObjectsCount();
             string newId = "new-id";
             testObj.GetComponent<RegisteredIdentifier>().AssignId(newId);
             yield return null;
             Assert.IsNull(objectRegistry.GetObjectWithGuid(currentId));
             Assert.AreEqual(testObj, objectRegistry.GetObjectWithGuid(newId));
-            Assert.AreEqual(1, objectRegistry.GetObjectsCount());
+            int objectsInfRegistryAfter = objectRegistry.GetObjectsCount();
+            Assert.AreEqual(objectsInRegistryBefore, objectsInfRegistryAfter);
             yield return null;
         }
         [UnityTest]

--- a/Tests/PlayMode/SetupBuildingTest.cs
+++ b/Tests/PlayMode/SetupBuildingTest.cs
@@ -32,10 +32,6 @@ namespace ReupVirtualTwinTests.behaviours
         [Test]
         public void ShouldAssignIdsToAllObjectsInBuilding()
         {
-            Assert.IsNull(building.GetComponent<RegisteredIdentifier>());
-            Assert.IsNull(child0.GetComponent<RegisteredIdentifier>());
-            Assert.IsNull(grandChild0.GetComponent<RegisteredIdentifier>());
-            setupbuilding.AssignIdsAndObjectInfoToBuilding();
             Assert.IsNotNull(building.GetComponent<RegisteredIdentifier>());
             Assert.IsNotNull(child0.GetComponent<RegisteredIdentifier>());
             Assert.IsNotNull(grandChild0.GetComponent<RegisteredIdentifier>());
@@ -44,10 +40,6 @@ namespace ReupVirtualTwinTests.behaviours
         [Test]
         public void ShouldAssignObjectInfoComponentToAllObjectsInBuilding()
         {
-            Assert.IsNull(building.GetComponent<ObjectInfo>());
-            Assert.IsNull(child0.GetComponent<ObjectInfo>());
-            Assert.IsNull(grandChild0.GetComponent<ObjectInfo>());
-            setupbuilding.AssignIdsAndObjectInfoToBuilding();
             Assert.IsNotNull(building.GetComponent<ObjectInfo>());
             Assert.IsNotNull(child0.GetComponent<ObjectInfo>());
             Assert.IsNotNull(grandChild0.GetComponent<ObjectInfo>());

--- a/Tests/PlayMode/TexturesManagerTest.cs
+++ b/Tests/PlayMode/TexturesManagerTest.cs
@@ -121,7 +121,6 @@ namespace ReupVirtualTwinTests.managers
         [UnityTest]
         public IEnumerator ShouldDestroyNonProtectedTextures_when_applyingProtectedTextures()
         {
-
             Texture2D nonProtectedTexture = new Texture2D(2, 2);
             Material nonProtectedMaterial = new Material(Shader.Find("Universal Render Pipeline/Lit"));
             nonProtectedMaterial.SetTexture("_BaseMap", nonProtectedTexture);

--- a/Tests/PlayMode/TexturesManagerTest.cs
+++ b/Tests/PlayMode/TexturesManagerTest.cs
@@ -1,0 +1,48 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEditor;
+
+using ReupVirtualTwin.managerInterfaces;
+using ReupVirtualTwinTests.utils;
+using NUnit.Framework;
+
+namespace ReupVirtualTwinTests.managers
+{
+    public class TexturesManagerTest : MonoBehaviour
+    {
+        GameObject testCubesPrefab = AssetDatabase.LoadAssetAtPath<GameObject>("Packages/com.reup.romulo/Tests/TestAssets/testCubes.prefab");
+        GameObject cube0;
+        ReupSceneInstantiator.SceneObjects sceneObjects;
+        ITexturesManager texturesManager;
+
+        [SetUp]
+        public void SetUp()
+        {
+            sceneObjects = ReupSceneInstantiator.InstantiateSceneWithBuildingFromPrefab(testCubesPrefab);
+            texturesManager = sceneObjects.texturesManager;
+            cube0 = sceneObjects.building.transform.Find("Cube0").gameObject;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            ReupSceneInstantiator.DestroySceneObjects(sceneObjects);
+        }
+
+        [Test]
+        public void ShouldApplyMaterialWithTextureToObject()
+        {
+            Material originalMaterial = cube0.GetComponent<Renderer>().material;
+            Texture2D newTexture = new Texture2D(2, 2);
+            Material newMaterial = new Material(Shader.Find("Universal Render Pipeline/Lit"));
+            newMaterial.SetTexture("_BaseMap", newTexture);
+            Assert.AreNotEqual(originalMaterial.GetTexture("_BaseMap"), newTexture);
+            texturesManager.ApplyMaterialToObject(cube0, newMaterial);
+            Material appliedMaterial = cube0.GetComponent<Renderer>().material;
+            Assert.AreEqual(appliedMaterial.GetTexture("_BaseMap"), newTexture);
+        }
+
+    }
+
+}

--- a/Tests/PlayMode/TexturesManagerTest.cs
+++ b/Tests/PlayMode/TexturesManagerTest.cs
@@ -82,6 +82,25 @@ namespace ReupVirtualTwinTests.managers
             Assert.IsFalse(newTexture1 == null);
         }
 
+        [UnityTest]
+        public IEnumerator ShouldDestroyTexture_if_textureIsNotUsedByAnyObject()
+        {
+            Texture2D newTexture1 = new Texture2D(2, 2);
+            Assert.IsFalse(newTexture1 == null);
+            Material newMaterial1 = new Material(Shader.Find("Universal Render Pipeline/Lit"));
+            newMaterial1.SetTexture("_BaseMap", newTexture1);
+            texturesManager.ApplyMaterialToObject(cube0, newMaterial1);
+            texturesManager.ApplyMaterialToObject(cube1, newMaterial1);
+            yield return null;
+            Texture2D newTexture2 = new Texture2D(2, 2);
+            Material newMaterial2 = new Material(Shader.Find("Universal Render Pipeline/Lit"));
+            newMaterial2.SetTexture("_BaseMap", newTexture2);
+            texturesManager.ApplyMaterialToObject(cube0, newMaterial2);
+            texturesManager.ApplyMaterialToObject(cube1, newMaterial2);
+            yield return null;
+            Assert.IsTrue(newTexture1 == null);
+        }
+
     }
 
 }

--- a/Tests/PlayMode/TexturesManagerTest.cs
+++ b/Tests/PlayMode/TexturesManagerTest.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -24,10 +25,11 @@ namespace ReupVirtualTwinTests.managers
             cube0 = sceneObjects.building.transform.Find("Cube0").gameObject;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             ReupSceneInstantiator.DestroySceneObjects(sceneObjects);
+            yield return null;
         }
 
         [Test]
@@ -41,6 +43,27 @@ namespace ReupVirtualTwinTests.managers
             texturesManager.ApplyMaterialToObject(cube0, newMaterial);
             Material appliedMaterial = cube0.GetComponent<Renderer>().material;
             Assert.AreEqual(appliedMaterial.GetTexture("_BaseMap"), newTexture);
+        }
+
+        [UnityTest]
+        public IEnumerator ShouldDestroyTexture_if_replacedByTheOnlyObjectWhereWasBeingUsed()
+        {
+            Texture2D newTexture1 = new Texture2D(2, 2);
+            Assert.IsFalse(newTexture1 == null);
+            Material newMaterial1 = new Material(Shader.Find("Universal Render Pipeline/Lit"));
+            newMaterial1.SetTexture("_BaseMap", newTexture1);
+            texturesManager.ApplyMaterialToObject(cube0, newMaterial1);
+            yield return null;
+
+            Texture2D newTexture2 = new Texture2D(2, 2);
+            Material newMaterial2 = new Material(Shader.Find("Universal Render Pipeline/Lit"));
+            newMaterial2.SetTexture("_BaseMap", newTexture2);
+            texturesManager.ApplyMaterialToObject(cube0, newMaterial2);
+            yield return null;
+
+            Material appliedMaterial = cube0.GetComponent<Renderer>().material;
+            Assert.AreEqual(appliedMaterial.GetTexture("_BaseMap"), newTexture2);
+            Assert.IsTrue(newTexture1 == null);
         }
 
     }

--- a/Tests/PlayMode/TexturesManagerTest.cs
+++ b/Tests/PlayMode/TexturesManagerTest.cs
@@ -101,6 +101,41 @@ namespace ReupVirtualTwinTests.managers
             Assert.IsTrue(newTexture1 == null);
         }
 
+        [UnityTest]
+        public IEnumerator ShouldNotDestroyTexturesFromProtectedMaterials()
+        {
+            Texture2D protectedTexture = new Texture2D(2, 2);
+            Assert.IsFalse(protectedTexture == null);
+            Material protectedMaterial = new Material(Shader.Find("Universal Render Pipeline/Lit"));
+            protectedMaterial.SetTexture("_BaseMap", protectedTexture);
+            texturesManager.ApplyProtectedMaterialToObject(cube0, protectedMaterial);
+            yield return null;
+            Texture2D nonProtectedTexture = new Texture2D(2, 2);
+            Material nonProtectedMaterial = new Material(Shader.Find("Universal Render Pipeline/Lit"));
+            nonProtectedMaterial.SetTexture("_BaseMap", nonProtectedTexture);
+            texturesManager.ApplyMaterialToObject(cube0, nonProtectedMaterial);
+            yield return null;
+            Assert.IsFalse(protectedTexture == null);
+        }
+
+        [UnityTest]
+        public IEnumerator ShouldDestroyNonProtectedTextures_when_applyingProtectedTextures()
+        {
+
+            Texture2D nonProtectedTexture = new Texture2D(2, 2);
+            Material nonProtectedMaterial = new Material(Shader.Find("Universal Render Pipeline/Lit"));
+            nonProtectedMaterial.SetTexture("_BaseMap", nonProtectedTexture);
+            texturesManager.ApplyMaterialToObject(cube0, nonProtectedMaterial);
+            yield return null;
+            Texture2D protectedTexture = new Texture2D(2, 2);
+            Material protectedMaterial = new Material(Shader.Find("Universal Render Pipeline/Lit"));
+            protectedMaterial.SetTexture("_BaseMap", protectedTexture);
+            texturesManager.ApplyProtectedMaterialToObject(cube0, protectedMaterial);
+            yield return null;
+            Assert.IsTrue(nonProtectedTexture == null);
+
+        }
+
     }
 
 }

--- a/Tests/PlayMode/TexturesManagerTest.cs
+++ b/Tests/PlayMode/TexturesManagerTest.cs
@@ -14,6 +14,7 @@ namespace ReupVirtualTwinTests.managers
     {
         GameObject testCubesPrefab = AssetDatabase.LoadAssetAtPath<GameObject>("Packages/com.reup.romulo/Tests/TestAssets/testCubes.prefab");
         GameObject cube0;
+        GameObject cube1;
         ReupSceneInstantiator.SceneObjects sceneObjects;
         ITexturesManager texturesManager;
 
@@ -23,6 +24,7 @@ namespace ReupVirtualTwinTests.managers
             sceneObjects = ReupSceneInstantiator.InstantiateSceneWithBuildingFromPrefab(testCubesPrefab);
             texturesManager = sceneObjects.texturesManager;
             cube0 = sceneObjects.building.transform.Find("Cube0").gameObject;
+            cube1 = sceneObjects.building.transform.Find("Cube1").gameObject;
         }
 
         [UnityTearDown]
@@ -54,16 +56,30 @@ namespace ReupVirtualTwinTests.managers
             newMaterial1.SetTexture("_BaseMap", newTexture1);
             texturesManager.ApplyMaterialToObject(cube0, newMaterial1);
             yield return null;
-
             Texture2D newTexture2 = new Texture2D(2, 2);
             Material newMaterial2 = new Material(Shader.Find("Universal Render Pipeline/Lit"));
             newMaterial2.SetTexture("_BaseMap", newTexture2);
             texturesManager.ApplyMaterialToObject(cube0, newMaterial2);
             yield return null;
-
-            Material appliedMaterial = cube0.GetComponent<Renderer>().material;
-            Assert.AreEqual(appliedMaterial.GetTexture("_BaseMap"), newTexture2);
             Assert.IsTrue(newTexture1 == null);
+        }
+
+        [UnityTest]
+        public IEnumerator ShouldNotDestroyTexture_if_textureIsStillBeingUsedInOtherObjects()
+        {
+            Texture2D newTexture1 = new Texture2D(2, 2);
+            Assert.IsFalse(newTexture1 == null);
+            Material newMaterial1 = new Material(Shader.Find("Universal Render Pipeline/Lit"));
+            newMaterial1.SetTexture("_BaseMap", newTexture1);
+            texturesManager.ApplyMaterialToObject(cube0, newMaterial1);
+            texturesManager.ApplyMaterialToObject(cube1, newMaterial1);
+            yield return null;
+            Texture2D newTexture2 = new Texture2D(2, 2);
+            Material newMaterial2 = new Material(Shader.Find("Universal Render Pipeline/Lit"));
+            newMaterial2.SetTexture("_BaseMap", newTexture2);
+            texturesManager.ApplyMaterialToObject(cube0, newMaterial2);
+            yield return null;
+            Assert.IsFalse(newTexture1 == null);
         }
 
     }

--- a/Tests/PlayMode/TexturesManagerTest.cs.meta
+++ b/Tests/PlayMode/TexturesManagerTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e8017e571d787154f80839670746f3b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/TestAssets/testCubes.prefab
+++ b/Tests/TestAssets/testCubes.prefab
@@ -1,0 +1,351 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &436612307098838007
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7944132897268539208}
+  m_Layer: 0
+  m_Name: testCubes
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7944132897268539208
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 436612307098838007}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3328876606443062515}
+  - {fileID: 4590214399508546642}
+  - {fileID: 8721377723448975433}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1143844289074835649
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8721377723448975433}
+  - component: {fileID: 1658153206463588247}
+  - component: {fileID: 7758784755060286644}
+  - component: {fileID: 9123066311241475938}
+  m_Layer: 0
+  m_Name: Cube2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8721377723448975433
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1143844289074835649}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.274, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7944132897268539208}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1658153206463588247
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1143844289074835649}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &7758784755060286644
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1143844289074835649}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &9123066311241475938
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1143844289074835649}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &4691426523948541790
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3328876606443062515}
+  - component: {fileID: 8608944210362851843}
+  - component: {fileID: 1657469252271251343}
+  - component: {fileID: 7524706183164101139}
+  m_Layer: 0
+  m_Name: Cube0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3328876606443062515
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4691426523948541790}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7944132897268539208}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8608944210362851843
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4691426523948541790}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1657469252271251343
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4691426523948541790}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &7524706183164101139
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4691426523948541790}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &9052517573146232345
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4590214399508546642}
+  - component: {fileID: 5820215379585267458}
+  - component: {fileID: 3052639547624326131}
+  - component: {fileID: 5419044177339639924}
+  m_Layer: 0
+  m_Name: Cube1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4590214399508546642
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9052517573146232345}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.145, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7944132897268539208}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5820215379585267458
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9052517573146232345}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &3052639547624326131
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9052517573146232345}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &5419044177339639924
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9052517573146232345}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Tests/TestAssets/testCubes.prefab.meta
+++ b/Tests/TestAssets/testCubes.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 90975617739a47a4ca38825820061b43
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/TestMocks/TexturesManagerSpy.cs
+++ b/Tests/TestMocks/TexturesManagerSpy.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using ReupVirtualTwin.managerInterfaces;
+using UnityEngine;
+
+namespace ReupVirtualTwinTests.mocks
+{
+    public class TexturesManagerSpy : ITexturesManager
+    {
+        public List<GameObject> calledObjectsToApplyMaterial = new List<GameObject>();
+        public List<Material> calledToApplyMaterials = new List<Material>();
+        public List<GameObject> calledObjectsToApplyProtectedMaterial = new List<GameObject>();
+        public List<Material> calledToApplyProtectedMaterials = new List<Material>();
+
+        public void ApplyMaterialToObject(GameObject obj, Material material)
+        {
+            calledObjectsToApplyMaterial.Add(obj);
+            calledToApplyMaterials.Add(material);
+        }
+
+        public void ApplyProtectedMaterialToObject(GameObject obj, Material material)
+        {
+            calledObjectsToApplyProtectedMaterial.Add(obj);
+            calledToApplyProtectedMaterials.Add(material);
+        }
+    }
+
+}

--- a/Tests/TestMocks/TexturesManagerSpy.cs.meta
+++ b/Tests/TestMocks/TexturesManagerSpy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28c139aa887e0d245b6d6b7256818448
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/TestUtils/ReupSceneInstantiator.cs
+++ b/Tests/TestUtils/ReupSceneInstantiator.cs
@@ -72,6 +72,7 @@ namespace ReupVirtualTwinTests.utils
             Transform dollhouseViewWrapper = reupGameObject.transform.Find("DollhouseViewWrapper");
 
             SetupBuilding setupBuilding = baseGlobalScriptGameObject.transform.Find("SetupBuilding").GetComponent<SetupBuilding>();
+
             setupBuilding.building = building;
             setupBuilding.AssignIdsAndObjectInfoToBuilding();
 

--- a/Tests/TestUtils/ReupSceneInstantiator.cs
+++ b/Tests/TestUtils/ReupSceneInstantiator.cs
@@ -7,6 +7,7 @@ using UnityEngine.InputSystem;
 using UnityEngine.EventSystems;
 using ReupVirtualTwin.models;
 using ReupVirtualTwin.helpers;
+using ReupVirtualTwin.managerInterfaces;
 
 namespace ReupVirtualTwinTests.utils
 {
@@ -38,6 +39,7 @@ namespace ReupVirtualTwinTests.utils
             public ObjectRegistry objectRegistry;
             public ObjectPool objectPool;
             public Camera mainCamera;
+            public ITexturesManager texturesManager;
         }
         public static SceneObjects InstantiateSceneWithBuildingFromPrefab(GameObject buildingPrefab)
         {
@@ -71,6 +73,7 @@ namespace ReupVirtualTwinTests.utils
 
             SetupBuilding setupBuilding = baseGlobalScriptGameObject.transform.Find("SetupBuilding").GetComponent<SetupBuilding>();
             setupBuilding.building = building;
+            setupBuilding.AssignIdsAndObjectInfoToBuilding();
 
             EditMediator editMediator = baseGlobalScriptGameObject.transform
                 .Find("EditMediator").GetComponent<EditMediator>();
@@ -97,7 +100,7 @@ namespace ReupVirtualTwinTests.utils
                 .Find("DollhouseViewWrapper")
                 .Find("VerticalRotationWrapper")
                 .Find("DHVCinemachineCamera").gameObject;
-                
+
             GameObject fpvCamera = character.transform.Find("InnerCharacter").Find("FPVCinemachineCamera").gameObject;
 
             ViewModeManager viewModeManager = baseGlobalScriptGameObject.transform
@@ -114,8 +117,10 @@ namespace ReupVirtualTwinTests.utils
             ObjectRegistry objectRegistry = baseGlobalScriptGameObject.transform.Find("ObjectRegistry").GetComponent<ObjectRegistry>();
 
             ObjectPool objectPool = baseGlobalScriptGameObject.transform.Find("ObjectPool").GetComponent<ObjectPool>();
-            
+
             Camera mainCamera = reupGameObject.transform.Find("Main_Camera").GetComponent<Camera>();
+
+            ITexturesManager texturesManager = baseGlobalScriptGameObject.transform.Find("TexturesManager").GetComponent<ITexturesManager>();
 
             return new SceneObjects
             {
@@ -142,6 +147,7 @@ namespace ReupVirtualTwinTests.utils
                 objectRegistry = objectRegistry,
                 objectPool = objectPool,
                 mainCamera = mainCamera,
+                texturesManager = texturesManager,
             };
         }
 

--- a/Tests/TestUtils/reup.romulo.tests.utils.asmdef
+++ b/Tests/TestUtils/reup.romulo.tests.utils.asmdef
@@ -15,7 +15,8 @@
         "GUID:0da6763f50b07ec4c9363bdf3985cee5",
         "GUID:3e29f3cf4a29b6f4a8ecdaccb3a3a2ba",
         "GUID:75469ad4d38634e559750d17036d5f7c",
-        "GUID:dc04f38471c3a459fb4d31124ee9127d"
+        "GUID:dc04f38471c3a459fb4d31124ee9127d",
+        "GUID:db1051acd1be67444bdd582f8c8da4bd"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
[Reup402](https://macheight-reup.atlassian.net/browse/REUP-402?atlOrigin=eyJpIjoiODFiN2ZkNjQyNDBkNDEwM2E4OWEwNjFkZTViZTc2NDYiLCJwIjoiaiJ9)

As a developer, I want to free the memory consumed by textures that are never going to be used again, so the model can run smoothly even after applying several new textures to objects.

AC:

All downloaded textures that are not used anymore, should be destroyed

Example: if a texture is downloaded and applied to an object, and later a new texture is downloaded and applied to that same object. The reference of the first texture should be lost, and the memory used to store it should be released

Original textures should never be deleted even when they are not used anymore, since they are still needed when loading a saved scene.

Notes:

The [unity profiler tool ](https://docs.unity3d.com/Manual/Profiler.html)would help to track memory consumption.