### PR TITLE
Fix tag filters being reset on tag addition

### DIFF
--- a/Editor/EditorSections/SelectTagsSection.cs
+++ b/Editor/EditorSections/SelectTagsSection.cs
@@ -13,7 +13,6 @@ namespace ReupVirtualTwin.editor
     public class SelectTagsSection
     {
         public List<Tag> selectedTags;
-        public Action<List<Tag>> onTagsChange { set => _onTagsChange = value; }
         public Action<Tag> onTagDeletion { set => _onTagDeletion = value; }
         public Action<Tag> onTagAddition { set => _onTagAddition = value; }
         public Action onTagReset { set => _onTagReset = value; }
@@ -21,7 +20,6 @@ namespace ReupVirtualTwin.editor
 
         private ITagsApiManager tagsApiManager;
         private List<Tag> allTags = new List<Tag>();
-        private Action<List<Tag>> _onTagsChange;
         private Action<Tag> _onTagDeletion;
         private Action<Tag> _onTagAddition;
         private Action _onTagReset;
@@ -97,7 +95,6 @@ namespace ReupVirtualTwin.editor
             if (!IsTagAlreadyPresent(tag))
             {
                 selectedTags.Add(tag);
-                _onTagsChange?.Invoke(selectedTags);
                 _onTagAddition?.Invoke(tag);
             }
         }

--- a/Editor/TagScannerTool.cs
+++ b/Editor/TagScannerTool.cs
@@ -34,7 +34,7 @@ namespace ReupVirtualTwin.editor
             CreateTagSection();
             SetSetupBuilding();
             sceneVisibilityManager = SceneVisibilityManager.instance;
-            OnTagsChange(selectedTags);
+            SetUpTagFilters(selectedTags);
         }
 
         private void OnGUI()
@@ -127,19 +127,28 @@ namespace ReupVirtualTwin.editor
                 EditorGUILayout.EndHorizontal();
             });
         }
-        private void OnTagsChange(List<Tag> tags)
+        private void SetUpTagFilters(List<Tag> tags)
         {
             tagFilters.Clear();
             tags.ForEach(tag =>
             {
-                ITagFilter tagFilter = new TagFilter(tag);
-                tagFilters.Add(tagFilter);
-                tagFilter.onRemoveFilter = () =>
-                {
-                    selectedTags.Remove(tag);
-                    tagFilters.Remove(tagFilter);
-                };
+                AddTagFilter(tag);
             });
+        }
+        private void OnTagAddition(Tag tag)
+        {
+            AddTagFilter(tag);
+        }
+
+        private void AddTagFilter(Tag tag)
+        {
+            ITagFilter tagFilter = new TagFilter(tag);
+            tagFilters.Add(tagFilter);
+            tagFilter.onRemoveFilter = () =>
+            {
+                selectedTags.Remove(tag);
+                tagFilters.Remove(tagFilter);
+            };
         }
         private void SetSetupBuilding()
         {
@@ -149,7 +158,7 @@ namespace ReupVirtualTwin.editor
         {
             ITagsApiManager tagsApiManager = TagsApiManagerEditorFinder.FindTagApiManager();
             selectTagsSection = await SelectTagsSection.Create(tagsApiManager, selectedTags);
-            selectTagsSection.onTagsChange = OnTagsChange;
+            selectTagsSection.onTagAddition = OnTagAddition;
         }
         private void ShowSubStringFilterAdder()
         {


### PR DESCRIPTION
[REUP-437](https://macheight-reup.atlassian.net/browse/REUP-437)

As a modeler, I want to keep the same filters and settings when adding a new filter to the tag scanner tool, so I don’t have to repeat the configuration for each filter again.

AC:

When adding a new filter in the tag scanner tool, any filter already present keeps its “invert filter“ checkbox  unchanged, and the new filter is added at the end of the filter list with its “invert filter” checkbox unchecked