### PR TITLE
Hide loading spinner when changing a material fails

### DIFF
--- a/Runtime/Enums/WebMessageType.cs
+++ b/Runtime/Enums/WebMessageType.cs
@@ -32,6 +32,7 @@ namespace ReupVirtualTwin.enums
 
         public const string changeObjectsMaterial = "[Change Material] Change Object Material";
         public const string changeObjectsMaterialSuccess = "[Change Material] Change Object Material Success";
+        public const string changeObjectsMaterialFailure = "[Change Material] Change Object Material Failure";
 
         public const string error = "[Error] Engine Error";
 

--- a/Runtime/Managers/EditMediator.cs
+++ b/Runtime/Managers/EditMediator.cs
@@ -217,7 +217,7 @@ namespace ReupVirtualTwin.managers
                     TaskResult result = await _changeMaterialController.ChangeObjectMaterial((JObject)payload);
                     if (!result.isSuccess) 
                     {
-                        SendErrorMessage(result.error);
+                        SendObjectMaterialsChangeFailure(result.error);
                         return;
                     }
                     ProcessObjectMaterialsChange((JObject)payload);
@@ -576,6 +576,17 @@ namespace ReupVirtualTwin.managers
                 payload = materialsChangedInfo
             };
             _webMessageSender.SendWebMessage(message);
+        }
+
+        private void SendObjectMaterialsChangeFailure(string message)
+        {
+            _webMessageSender.SendWebMessage(new WebMessage<JObject>
+            {
+                type = WebMessageType.changeObjectsMaterialFailure,
+                payload = new JObject(
+                    new JProperty("errorMessage", message)
+                )
+            });
         }
 
         private void SendErrorMessage(string message)

--- a/Tests/PlayMode/EditMediatorTest.cs
+++ b/Tests/PlayMode/EditMediatorTest.cs
@@ -801,8 +801,8 @@ public class EditMediatorTest : MonoBehaviour
         string serializedMessage = JsonConvert.SerializeObject(requesMessage);
         await editMediator.ReceiveWebMessage(serializedMessage);
 
-        WebMessage<string> sentMessage = (WebMessage<string>)mockWebMessageSender.sentMessages[0];
-        Assert.AreEqual(WebMessageType.error, sentMessage.type);
+        WebMessage<JObject> sentMessage = (WebMessage<JObject>)mockWebMessageSender.sentMessages[0];
+        Assert.AreEqual(WebMessageType.changeObjectsMaterialFailure, sentMessage.type);
     }
 
     [UnityTest]


### PR DESCRIPTION
[REUP-415](https://macheight-reup.atlassian.net/browse/REUP-415)

As a developer, I want to properly receive and handle a message indicating that a material change has failed in unity, so the website is still functional after such failure.

AC:

When send a “change material” message to unity, and unity fails to download the texture, the loading spinner should be hidden and a proper toastr error message should display the failure’s reason.

Ideas:

Implement a failure message and use the same pattern of the component directly listening for changes in the store

Implement a service that abstracts the communication with unity and handles in its own the answers unity send back