### PR TITLE
Reup341 optimize object registry

### DIFF
--- a/Runtime/ModelInterfaces/IObjectRegistry.cs
+++ b/Runtime/ModelInterfaces/IObjectRegistry.cs
@@ -6,7 +6,7 @@ namespace ReupVirtualTwin.modelInterfaces
     public interface IObjectRegistry
     {
         public void AddObject(GameObject item);
-        public void RemoveObject(GameObject item);
+        public void RemoveObject(string id, GameObject item);
         public GameObject GetObjectWithGuid(string guid);
         public List<GameObject> GetObjectsWithGuids(string[] guids);
         public int GetObjectsCount();

--- a/Runtime/Models/ObjectRegistry.cs
+++ b/Runtime/Models/ObjectRegistry.cs
@@ -1,13 +1,14 @@
 using System.Collections.Generic;
 using UnityEngine;
 using ReupVirtualTwin.modelInterfaces;
+using System.Linq;
 
 namespace ReupVirtualTwin.models
 {
     public class ObjectRegistry : MonoBehaviour, IObjectRegistry
     {
         [HideInInspector]
-        public List<GameObject> objects = new List<GameObject>();
+        public Dictionary<string, GameObject> objects = new Dictionary<string, GameObject>();
 
         public void AddObject(GameObject item)
         {
@@ -16,30 +17,22 @@ namespace ReupVirtualTwin.models
             {
                 throw new System.Exception("Object must have a unique identifier");
             }
-            objects.Add(item);
+            string guid = uniqueIdentifier.getId();
+            objects.Add(guid, item);
         }
         public void RemoveObject(GameObject item)
         {
-            objects.Remove(item);
+            objects.Remove(item.GetComponent<IUniqueIdentifier>().getId());
         }
 
         public GameObject GetObjectWithGuid(string guid)
         {
-            foreach (GameObject obj in objects)
-            {
-                if (obj == null) continue;
-                var uniqueIdentifier = obj.GetComponent<IUniqueIdentifier>();
-                if (uniqueIdentifier.isIdCorrect(guid))
-                {
-                    return obj;
-                }
-            }
-            return null;
+            return objects[guid];
         }
         public List<GameObject> GetObjectsWithGuids(string[] guids)
         {
             var foundObjects = new List<GameObject>();
-            foreach(string  guid in guids)
+            foreach (string guid in guids)
             {
                 foundObjects.Add(GetObjectWithGuid(guid));
             }
@@ -57,7 +50,7 @@ namespace ReupVirtualTwin.models
 
         public List<GameObject> GetObjects()
         {
-            return objects;
+            return objects.Values.ToList();
         }
     }
 }

--- a/Runtime/Models/ObjectRegistry.cs
+++ b/Runtime/Models/ObjectRegistry.cs
@@ -7,8 +7,7 @@ namespace ReupVirtualTwin.models
 {
     public class ObjectRegistry : MonoBehaviour, IObjectRegistry
     {
-        [HideInInspector]
-        public Dictionary<string, GameObject> objects = new Dictionary<string, GameObject>();
+        [HideInInspector] public Dictionary<string, GameObject> objects = new Dictionary<string, GameObject>();
 
         public void AddObject(GameObject item)
         {
@@ -18,16 +17,25 @@ namespace ReupVirtualTwin.models
                 throw new System.Exception("Object must have a unique identifier");
             }
             string guid = uniqueIdentifier.getId();
+            if (objects.ContainsKey(guid))
+            {
+                throw new System.Exception($"An object with id '{guid}' already exists in registry, can't add object '{item.name}'");
+            }
             objects.Add(guid, item);
         }
-        public void RemoveObject(GameObject item)
+        public void RemoveObject(string id, GameObject item)
         {
-            objects.Remove(item.GetComponent<IUniqueIdentifier>().getId());
+            GameObject registeredItem = objects.GetValueOrDefault(id);
+            if (registeredItem != item && registeredItem != null)
+            {
+                throw new System.Exception($"Object with id '{id}' is not the same as the object being removed '{item.name}'");
+            }
+            objects.Remove(id);
         }
 
         public GameObject GetObjectWithGuid(string guid)
         {
-            return objects[guid];
+            return objects.GetValueOrDefault(guid);
         }
         public List<GameObject> GetObjectsWithGuids(string[] guids)
         {

--- a/Runtime/Models/RegisteredIdentifier.cs
+++ b/Runtime/Models/RegisteredIdentifier.cs
@@ -1,7 +1,6 @@
 using ReupVirtualTwin.helpers;
 using UnityEngine;
 using ReupVirtualTwin.modelInterfaces;
-using System.Collections.Generic;
 
 namespace ReupVirtualTwin.models
 {
@@ -12,18 +11,24 @@ namespace ReupVirtualTwin.models
 
         override protected void Start()
         {
+            if (manualId != uniqueId && !string.IsNullOrEmpty(manualId))
+            {
+                uniqueId = manualId;
+            }
             FindObjectRegistry();
             base.Start();
         }
 
         override public string GenerateId()
         {
+
             if (_objectRegistry == null)
             {
                 FindObjectRegistry();
             }
+            UnRegisterObject();
             base.GenerateId();
-            UpdateRegistry();
+            RegisterObject();
             return uniqueId;
         }
 
@@ -33,34 +38,42 @@ namespace ReupVirtualTwin.models
             {
                 FindObjectRegistry();
             }
+            UnRegisterObject();
             base.AssignId(id);
-            UpdateRegistry();
+            RegisterObject();
             return uniqueId;
         }
-
-        private void UpdateRegistry()
-        {
-            UnRegisterObject();
-            RegisterObject();
-        }
-
         private void RegisterObject()
         {
-            if (manualId != uniqueId && !string.IsNullOrEmpty(manualId))
-            {
-                uniqueId = manualId;
-            }
             _objectRegistry.AddObject(gameObject);
         }
 
         private void UnRegisterObject()
         {
-            _objectRegistry.RemoveObject(gameObject);
+            string id = gameObject.GetComponent<IUniqueIdentifier>()?.getId();
+            if (string.IsNullOrEmpty(id))
+            {
+                return;
+            }
+            GameObject registeredItem = _objectRegistry.GetObjectWithGuid(id);
+            if (registeredItem == gameObject)
+            {
+                _objectRegistry.RemoveObject(id, gameObject);
+            }
         }
 
         private void FindObjectRegistry()
         {
             _objectRegistry = ObjectFinder.FindObjectRegistry().GetComponent<IObjectRegistry>();
+        }
+
+        public override string getId()
+        {
+            if (string.IsNullOrEmpty(manualId))
+            {
+                return base.getId();
+            }
+            return manualId;
         }
 
     }

--- a/Runtime/Models/UniqueId.cs
+++ b/Runtime/Models/UniqueId.cs
@@ -4,12 +4,12 @@ using ReupVirtualTwin.modelInterfaces;
 
 namespace ReupVirtualTwin.models
 {
-	public class UniqueIdentifierAttribute : PropertyAttribute { }
+    public class UniqueIdentifierAttribute : PropertyAttribute { }
 
-	public class UniqueId : MonoBehaviour, IUniqueIdentifier
-	{
-		[UniqueIdentifier]
-		public string uniqueId;
+    public class UniqueId : MonoBehaviour, IUniqueIdentifier
+    {
+        [UniqueIdentifier]
+        public string uniqueId;
 
         protected virtual void Start()
         {
@@ -36,7 +36,7 @@ namespace ReupVirtualTwin.models
             return uniqueId;
         }
 
-        public string getId()
+        public virtual string getId()
         {
             return uniqueId;
         }

--- a/Tests/PlayMode/DeleteObjectsManagerTest.cs
+++ b/Tests/PlayMode/DeleteObjectsManagerTest.cs
@@ -65,7 +65,7 @@ public class DeleteObjectsManagerTest : MonoBehaviour
     [UnityTest]
     public IEnumerator ShouldFailWhenTryingToDeleteNonDeletableObjects()
     {
-        List<GameObject> gameObjects = new List<GameObject>() { allObjects[0], allObjects[1], allObjects[2]};
+        List<GameObject> gameObjects = new List<GameObject>() { allObjects[0], allObjects[1], allObjects[2] };
         string stringIDs = ListToString(GetIDsList(gameObjects));
         Assert.IsEmpty(deleteObjectsManager.GetDeletableObjects(stringIDs));
         yield return null;
@@ -78,7 +78,8 @@ public class DeleteObjectsManagerTest : MonoBehaviour
 
         public void Notify(ReupEvent eventName)
         {
-            if (eventName == ReupEvent.objectsDeleted){
+            if (eventName == ReupEvent.objectsDeleted)
+            {
                 notified = true;
             }
         }
@@ -100,7 +101,7 @@ public class DeleteObjectsManagerTest : MonoBehaviour
             deletableObject1.AddComponent<ObjectTags>().AddTags(new Tag[2] { EditionTagsCreator.CreateSelectableTag(), EditionTagsCreator.CreateDeletableTag() });
             deletableObject1.AddComponent<UniqueId>().GenerateId();
             GameObject nonDeletableObject = new GameObject("nonDeletableObject");
-            nonDeletableObject.AddComponent<ObjectTags>().AddTags(new Tag[1] {EditionTagsCreator.CreateSelectableTag()});
+            nonDeletableObject.AddComponent<ObjectTags>().AddTags(new Tag[1] { EditionTagsCreator.CreateSelectableTag() });
             nonDeletableObject.AddComponent<UniqueId>().GenerateId();
             allObjects.Add(deletableObject0);
             allObjects.Add(deletableObject1);
@@ -138,7 +139,7 @@ public class DeleteObjectsManagerTest : MonoBehaviour
             throw new NotImplementedException();
         }
 
-        public void RemoveObject(GameObject item)
+        public void RemoveObject(string id, GameObject item)
         {
             throw new NotImplementedException();
         }

--- a/Tests/PlayMode/IdControllerTest.cs
+++ b/Tests/PlayMode/IdControllerTest.cs
@@ -3,12 +3,9 @@ using UnityEngine;
 using UnityEngine.TestTools;
 using NUnit.Framework;
 using ReupVirtualTwin.models;
-using UnityEditor;
 using ReupVirtualTwin.modelInterfaces;
 using ReupVirtualTwin.controllers;
 using ReupVirtualTwinTests.utils;
-
-
 
 namespace ReupVirtualTwinTests.Registry
 {
@@ -38,7 +35,7 @@ namespace ReupVirtualTwinTests.Registry
             grandchild00.transform.parent = child0.transform;
             yield return null;
         }
-        
+
         [UnityTearDown]
         public IEnumerator TearDownCoroutine()
         {
@@ -46,6 +43,7 @@ namespace ReupVirtualTwinTests.Registry
             Destroy(child0);
             Destroy(child1);
             Destroy(grandchild00);
+            objectRegistry.ClearRegistry();
             ReupSceneInstantiator.DestroySceneObjects(sceneObjects);
             yield return null;
         }
@@ -165,17 +163,16 @@ namespace ReupVirtualTwinTests.Registry
             yield return null;
         }
 
-        [UnityTest]
-        public IEnumerator ShouldFindRepeatedIds()
+        [Test]
+        public void ShouldFindRepeatedIds()
         {
             idController.AssignIdsToTree(parent);
-            IUniqueIdentifier identifierParent = parent.GetComponent<IUniqueIdentifier>();
-            IUniqueIdentifier identifierChild0 = child0.GetComponent<IUniqueIdentifier>();
+            RegisteredIdentifier identifierParent = parent.GetComponent<RegisteredIdentifier>();
+            RegisteredIdentifier identifierChild0 = child0.GetComponent<RegisteredIdentifier>();
             string repeatedId = identifierParent.getId();
-            identifierChild0.AssignId(repeatedId);
-            bool hasRepeteaded = idController.HasRepeatedIds(parent);
-            Assert.IsTrue(hasRepeteaded);
-            yield return null;
+            identifierChild0.manualId = repeatedId;
+            bool hasRepeated = idController.HasRepeatedIds(parent);
+            Assert.IsTrue(hasRepeated);
         }
         [UnityTest]
         public IEnumerator ShouldThrow_if_objectDoesNotHaveId()

--- a/Tests/PlayMode/ObjectRegistryTests.cs
+++ b/Tests/PlayMode/ObjectRegistryTests.cs
@@ -3,9 +3,9 @@ using UnityEngine;
 using UnityEngine.TestTools;
 using NUnit.Framework;
 using ReupVirtualTwin.models;
-using UnityEditor;
 using ReupVirtualTwin.modelInterfaces;
 using ReupVirtualTwinTests.utils;
+using System;
 
 namespace ReupVirtualTwinTests.Registry
 {
@@ -97,7 +97,7 @@ namespace ReupVirtualTwinTests.Registry
             Assert.AreEqual(1, objectRegistry.GetObjectsCount());
             yield return null;
 
-            objectRegistry.RemoveObject(testObj0);
+            objectRegistry.RemoveObject(id, testObj0);
             Assert.AreEqual(0, objectRegistry.GetObjectsCount());
             Assert.IsNull(objectRegistry.GetObjectWithGuid(id));
             yield return null;
@@ -119,17 +119,39 @@ namespace ReupVirtualTwinTests.Registry
             Assert.AreEqual(0, objectRegistry.GetObjectsCount());
             yield return null;
         }
+
         [UnityTest]
-        public IEnumerator ShouldNotRaiseAnyExeptionIfAttemptToRemoveItemNotInRegistry()
+        public IEnumerator ShouldRaiseError_if_twoObjectsWithSameIdAreAttemptedToBeRegistered()
         {
+            string repeatedId = "repeated-id";
             testObj0 = new GameObject("testObj0");
-            testObj0.AddComponent<UniqueId>().GenerateId();
+            testObj0.AddComponent<UniqueId>().AssignId(repeatedId);
+
             testObj1 = new GameObject("testObj1");
+            testObj1.AddComponent<UniqueId>().AssignId(repeatedId);
+
             objectRegistry.AddObject(testObj0);
-            Assert.AreEqual(1, objectRegistry.GetObjectsCount());
+            Assert.That(() => objectRegistry.AddObject(testObj1),
+                Throws.TypeOf<Exception>()
+            );
+
             yield return null;
-            objectRegistry.RemoveObject(testObj1);
-            Assert.AreEqual(1, objectRegistry.GetObjectsCount());
+        }
+
+        [UnityTest]
+        public IEnumerator ShouldRaiseError_if_provideIncorrectIdAndObjectToBeRemoved()
+        {
+            string id = "test-id";
+            testObj0 = new GameObject("testObj0");
+            testObj0.AddComponent<UniqueId>().AssignId(id);
+            yield return null;
+
+            objectRegistry.AddObject(testObj0);
+            testObj1 = new GameObject("testObj1");
+            Assert.That(() => objectRegistry.RemoveObject(id, testObj1),
+                Throws.TypeOf<Exception>()
+            );
+
             yield return null;
         }
 

--- a/Tests/TestMocks/ObjectRegistrySpy.cs
+++ b/Tests/TestMocks/ObjectRegistrySpy.cs
@@ -56,7 +56,7 @@ namespace ReupVirtualTwinTests.mocks
             throw new System.NotImplementedException();
         }
 
-        public void RemoveObject(GameObject item)
+        public void RemoveObject(string id, GameObject item)
         {
             throw new System.NotImplementedException();
         }

--- a/Tests/TestMocks/SomeObjectWithMaterialRegistrySpy.cs
+++ b/Tests/TestMocks/SomeObjectWithMaterialRegistrySpy.cs
@@ -48,14 +48,14 @@ namespace ReupVirtualTwinTests.mocks
             throw new System.NotImplementedException();
         }
 
-        public void RemoveObject(GameObject item)
+        public void RemoveObject(string id, GameObject item)
         {
             throw new System.NotImplementedException();
         }
 
         public void DestroyAllObjects()
         {
-            for(int i = 0; i < objects.Count; i++)
+            for (int i = 0; i < objects.Count; i++)
             {
                 Object.Destroy(objects[i]);
             }


### PR DESCRIPTION
[Reup341](https://macheight-reup.atlassian.net/browse/REUP-341?atlOrigin=eyJpIjoiN2E5MDAyMGNmODZhNGNmNDk3NDRlZWE3ZGJmMGE3NGUiLCJwIjoiaiJ9)

As a developer, I want the object registry to implement a hash map instead of a list to store objects, so our search time complexity can go from O(n) to O(1)

object registry stores references to all objects in a `Dictionary<string, GameObject>` data structure.

