### PR TITLE
Fix textures being destroyed

### DIFF
--- a/Runtime/Managers/TexturesManager.cs
+++ b/Runtime/Managers/TexturesManager.cs
@@ -20,20 +20,31 @@ namespace ReupVirtualTwin.managers
 
         public void ApplyMaterialToObject(GameObject obj, Material material)
         {
-            ApplyMaterial(obj, material);
+            if (!ApplyMaterial(obj, material))
+            {
+                return;
+            }
             UpdateRecords(obj);
         }
 
         public void ApplyProtectedMaterialToObject(GameObject obj, Material material)
         {
-            ApplyMaterial(obj, material);
+            if (!ApplyMaterial(obj, material))
+            {
+                return;
+            }
             CleanAllObjectRecords(obj);
         }
 
-        void ApplyMaterial(GameObject obj, Material material)
+        bool ApplyMaterial(GameObject obj, Material material)
         {
             Renderer renderer = obj.GetComponent<Renderer>();
+            if (renderer.material.GetTexture("_BaseMap") == material.GetTexture("_BaseMap"))
+            {
+                return false;
+            }
             renderer.material = material;
+            return true;
         }
 
         void UpdateRecords(GameObject obj)

--- a/Tests/PlayMode/TexturesManagerTest.cs
+++ b/Tests/PlayMode/TexturesManagerTest.cs
@@ -132,7 +132,28 @@ namespace ReupVirtualTwinTests.managers
             texturesManager.ApplyProtectedMaterialToObject(cube0, protectedMaterial);
             yield return null;
             Assert.IsTrue(nonProtectedTexture == null);
+        }
 
+        [UnityTest]
+        public IEnumerator ShouldDoNothing_when_RequestedToApplyMaterialToObjectThatAlreadyHasSuchMaterial()
+        {
+            Texture2D texture = new Texture2D(2, 2);
+            Material material = new Material(Shader.Find("Universal Render Pipeline/Lit"));
+            Texture appliedTexture;
+            material.SetTexture("_BaseMap", texture);
+
+            texturesManager.ApplyMaterialToObject(cube0, material);
+            yield return null;
+            appliedTexture = cube0.GetComponent<Renderer>().material.GetTexture("_BaseMap");
+            Assert.NotNull(appliedTexture);
+            Assert.AreEqual(appliedTexture, texture);
+
+            texturesManager.ApplyMaterialToObject(cube0, material);
+            yield return null;
+            appliedTexture = cube0.GetComponent<Renderer>().material.GetTexture("_BaseMap");
+
+            Assert.NotNull(appliedTexture);
+            Assert.AreEqual(appliedTexture, texture);
         }
 
     }


### PR DESCRIPTION
Textures were being destroyied when applying a texture to an object that already had that texture, and it was the only object with such texture