### PR TITLE
Reup447 - Destroy used game objects in unity tests

### DIFF
--- a/Runtime/DependencyInjectors/TransformObjectsManagerDependenyInector.cs
+++ b/Runtime/DependencyInjectors/TransformObjectsManagerDependenyInector.cs
@@ -11,14 +11,19 @@ namespace ReupVirtualTwin.dependencyInjectors
     {
         [SerializeField]
         GameObject mediator;
+        GameObject transformHandleObj;
         private void Awake()
         {
             TransformObjectsManager transformObjectsManager = GetComponent<TransformObjectsManager>();
             transformObjectsManager.mediator = mediator.GetComponent<IMediator>();
-            GameObject transformHandleObj = new GameObject("TransformHandle");
+            transformHandleObj = new GameObject("TransformHandle");
             transformHandleObj.AddComponent<RuntimeTransformHandle>();
             transformObjectsManager.runtimeTransformObj = transformHandleObj;
             transformObjectsManager.tagsController = new TagsController();
+        }
+        private void OnDestroy() 
+        {
+            Destroy(transformHandleObj);
         }
     }
 }

--- a/Tests/PlayMode/BoundariesUtilsTest.cs
+++ b/Tests/PlayMode/BoundariesUtilsTest.cs
@@ -7,12 +7,30 @@ using NUnit.Framework;
 
 public class BoundariesUtilsTest
 {
+    GameObject parent;
+    GameObject child1;
+    GameObject child2;
+
+    [SetUp]
+    public void Setup()
+    {
+        parent = new GameObject();
+        child1 = new GameObject();
+        child2 = new GameObject();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        GameObject.DestroyImmediate(parent);
+        GameObject.DestroyImmediate(child1);
+        GameObject.DestroyImmediate(child2);
+    }
+
     [Test]
     public void CalculateCenter_ReturnsZero_WhenNoRenderers()
     {
-        GameObject emptyObj = new GameObject();
-
-        Vector3 center = BoundariesUtils.CalculateCenter(emptyObj);
+        Vector3 center = BoundariesUtils.CalculateCenter(parent);
 
         Assert.AreEqual(Vector3.zero, center);
     }
@@ -20,11 +38,9 @@ public class BoundariesUtilsTest
     [Test]
     public void CalculateCenter_ReturnsCenter_ForSingleRenderer()
     {
-        GameObject obj = new GameObject();
-        Renderer renderer = obj.AddComponent<MeshRenderer>();
-        renderer.bounds = new Bounds(Vector3.one * 5, Vector3.one * 10);
+        parent.AddComponent<MeshRenderer>().bounds = new Bounds(Vector3.one * 5, Vector3.one * 10);
         
-        Vector3 center = BoundariesUtils.CalculateCenter(obj);
+        Vector3 center = BoundariesUtils.CalculateCenter(parent);
 
         Assert.AreEqual(Vector3.one * 5, center);
     }
@@ -32,19 +48,13 @@ public class BoundariesUtilsTest
     [Test]
     public void CalculateCenter_ReturnsCombinedCenter_ForMultipleRenderers()
     {
-        GameObject obj = new GameObject();
-        
-        GameObject child1 = new GameObject();
-        child1.transform.parent = obj.transform;
-        Renderer renderer1 = child1.AddComponent<MeshRenderer>();
-        renderer1.bounds = new Bounds(Vector3.zero, Vector3.one * 10); // Center (0,0,0), Size (10,10,10)
+        parent.AddComponent<MeshRenderer>();
+        child1.transform.parent = parent.transform;
+        child1.AddComponent<MeshRenderer>().bounds = new Bounds(Vector3.zero, Vector3.one * 10); // Center (0,0,0), Size (10,10,10)
+        child2.transform.parent = parent.transform;
+        child2.AddComponent<MeshRenderer>().bounds = new Bounds(Vector3.one * 10, Vector3.one * 10); // Center (10,10,10), Size (10,10,10)
 
-        GameObject child2 = new GameObject();
-        child2.transform.parent = obj.transform;
-        Renderer renderer2 = child2.AddComponent<MeshRenderer>();
-        renderer2.bounds = new Bounds(Vector3.one * 10, Vector3.one * 10); // Center (10,10,10), Size (10,10,10)
-
-        Vector3 center = BoundariesUtils.CalculateCenter(obj);
+        Vector3 center = BoundariesUtils.CalculateCenter(parent);
 
         Vector3 expectedCenter = new Vector3(5, 5, 5);
         Assert.AreEqual(expectedCenter, center);

--- a/Tests/PlayMode/ChangeColorObjectsTest.cs
+++ b/Tests/PlayMode/ChangeColorObjectsTest.cs
@@ -32,10 +32,10 @@ public class ChangeColorObjectsTest : MonoBehaviour
     public void TearDown()
     {
         ReupSceneInstantiator.DestroySceneObjects(sceneObjects);
-        Destroy(meshedParent);
-        Destroy(unmeshedParent);
-        Destroy(meshedChild);
-        Destroy(unmeshedChild);
+        GameObject.DestroyImmediate(meshedParent);
+        GameObject.DestroyImmediate(unmeshedParent);
+        GameObject.DestroyImmediate(meshedChild);
+        GameObject.DestroyImmediate(unmeshedChild);
     }
     private void CreateObjects()
     {

--- a/Tests/PlayMode/ColliderAdderTest.cs
+++ b/Tests/PlayMode/ColliderAdderTest.cs
@@ -4,11 +4,12 @@ using UnityEngine;
 
 public class ColliderAdderTest
 {
-    [Test]
-    public void AddCollidersToObjectsWithNoColliders()
+    GameObject parentObject;
+
+    [SetUp]
+    public void SetUp()
     {
-        //Create objects
-        var parentObject = new GameObject();
+        parentObject = new GameObject();
         MeshFilter parentMeshFilter = parentObject.AddComponent<MeshFilter>();
         parentMeshFilter.sharedMesh = new Mesh();
         for (int i = 0; i < 10; i++)
@@ -18,7 +19,17 @@ public class ColliderAdderTest
             MeshFilter childMeshFilter = childObject.AddComponent<MeshFilter>();
             childMeshFilter.sharedMesh = new Mesh();
         }
+    }
 
+    [TearDown]
+    public void TearDown()
+    {
+        GameObject.DestroyImmediate(parentObject);
+    }
+
+    [Test]
+    public void AddCollidersToObjectsWithNoColliders()
+    {
         //Check colliders are not there
         Assert.IsNull(parentObject.GetComponent<Collider>());
         foreach (Transform childTransform in parentObject.transform)

--- a/Tests/PlayMode/CollisionDetectorTest.cs
+++ b/Tests/PlayMode/CollisionDetectorTest.cs
@@ -13,25 +13,28 @@ public class CollisionDetectorTest : MonoBehaviour
     Transform character;
 
     CharacterPositionManager posManager;
-    GameObject cubePrefab = AssetDatabase.LoadAssetAtPath<GameObject>("Packages/com.reup.romulo/Tests/TestAssets/Cube.prefab");
+    GameObject cubePrefab;
     GameObject widePlatform;
     GameObject wall;
 
     [SetUp]
     public void SetUp()
     {
+        cubePrefab = AssetDatabase.LoadAssetAtPath<GameObject>("Packages/com.reup.romulo/Tests/TestAssets/Cube.prefab");
         sceneObjects = ReupSceneInstantiator.InstantiateScene();
         character = sceneObjects.character;
         posManager = character.GetComponent<CharacterPositionManager>();
+        wall = (GameObject)PrefabUtility.InstantiatePrefab(cubePrefab);
         widePlatform = (GameObject)PrefabUtility.InstantiatePrefab(cubePrefab);
         SetPlatform();
+        SetWallAt2MetersInZAxis();
     }
 
     [UnityTearDown]
     public IEnumerator TearDown()
     {
-        Destroy(widePlatform);
-        Destroy(wall);
+        GameObject.DestroyImmediate(widePlatform);
+        GameObject.DestroyImmediate(wall);
         ReupSceneInstantiator.DestroySceneObjects(sceneObjects);
         yield return null;
     }
@@ -39,9 +42,6 @@ public class CollisionDetectorTest : MonoBehaviour
     [UnityTest]
     public IEnumerator CharacterShouldNotCrossWall()
     {
-        wall = (GameObject)PrefabUtility.InstantiatePrefab(cubePrefab);
-        SetWallAt2MetersInZAxis();
-
         character.transform.position = new Vector3(0, 1.5f, 0);
         yield return new WaitForSeconds(0.2f);
 
@@ -50,8 +50,6 @@ public class CollisionDetectorTest : MonoBehaviour
         yield return new WaitForSeconds(2f);
 
         Assert.LessOrEqual(character.transform.position.z, 2);
-
-        Destroy(wall);
     }
     private void SetPlatform()
     {

--- a/Tests/PlayMode/DeleteObjectsManagerTest.cs
+++ b/Tests/PlayMode/DeleteObjectsManagerTest.cs
@@ -33,6 +33,12 @@ public class DeleteObjectsManagerTest : MonoBehaviour
         deleteObjectsManager.registry = mockRegistry;
         allObjects = mockRegistry.allObjects;
     }
+    [TearDown]
+    public void TearDown()
+    {
+        GameObject.DestroyImmediate(containerGameObject);
+        mockRegistry.DestroyTestObjects();
+    }
     public string ListToString(List<string> idsList)
     {
         string idsString = string.Join(",", idsList);
@@ -157,6 +163,13 @@ public class DeleteObjectsManagerTest : MonoBehaviour
         public List<GameObject> GetObjects()
         {
             throw new NotImplementedException();
+        }
+        public void DestroyTestObjects()
+        {
+            foreach (GameObject obj in allObjects)
+            {
+                GameObject.DestroyImmediate(obj);
+            }
         }
     }
 

--- a/Tests/PlayMode/EditModeManagerTest.cs
+++ b/Tests/PlayMode/EditModeManagerTest.cs
@@ -21,6 +21,12 @@ public class EditModeManagerTest : MonoBehaviour
         editModeManager.mediator = mockMediator;
     }
 
+    [TearDown]
+    public void TearDown()
+    {
+        GameObject.DestroyImmediate(containerGameObject);
+    }
+
     [UnityTest]
     public IEnumerator EditModeManagerShouldNotifyMediatorWhenSettingEditMode()
     {

--- a/Tests/PlayMode/FollowCharacterTest.cs
+++ b/Tests/PlayMode/FollowCharacterTest.cs
@@ -34,8 +34,8 @@ public class FollowCharacterTest
     [TearDown]
     public void TearDown()
     {
-        UnityEngine.Object.Destroy(character);
-        UnityEngine.Object.Destroy(materialPicker);
+        GameObject.DestroyImmediate(character);
+        GameObject.DestroyImmediate(materialPicker);
     }
 
     [UnityTest]

--- a/Tests/PlayMode/InsertObjectControllerTest.cs
+++ b/Tests/PlayMode/InsertObjectControllerTest.cs
@@ -83,6 +83,7 @@ namespace ReupVirtualTwinTests.controllers
         public IEnumerator TearDown()
         {
             ReupSceneInstantiator.DestroySceneObjects(sceneObjects);
+            meshDownloaderSpy.DestroyLoadedObject();
             yield return null;
         }
 
@@ -305,6 +306,14 @@ namespace ReupVirtualTwinTests.controllers
             private class AssetLoaderContextStub
             {
                 public GameObject RootGameObject;
+            }
+
+            public void DestroyLoadedObject()
+            {
+                foreach(GameObject loadObj in loadedObjects)
+                {
+                    GameObject.DestroyImmediate(loadObj);
+                }
             }
         }
         private class MockModelInfoManager : IModelInfoManager

--- a/Tests/PlayMode/MaintainHeightTest.cs
+++ b/Tests/PlayMode/MaintainHeightTest.cs
@@ -12,7 +12,7 @@ using ReupVirtualTwinTests.utils;
 public class MaintainHeightTest : MonoBehaviour
 {
     ReupSceneInstantiator.SceneObjects sceneObjects;
-    GameObject platformPrefab = AssetDatabase.LoadAssetAtPath<GameObject>("Packages/com.reup.romulo/Tests/TestAssets/Platform.prefab");
+    GameObject platformPrefab;
     Transform character;
     GameObject widePlatform;
 
@@ -21,6 +21,7 @@ public class MaintainHeightTest : MonoBehaviour
     [SetUp]
     public void SetUp()
     {
+        platformPrefab = AssetDatabase.LoadAssetAtPath<GameObject>("Packages/com.reup.romulo/Tests/TestAssets/Platform.prefab");
         sceneObjects = ReupSceneInstantiator.InstantiateScene();
         character = sceneObjects.character;
         var posManager = character.GetComponent<ICharacterPositionManager>();
@@ -32,7 +33,7 @@ public class MaintainHeightTest : MonoBehaviour
     [UnityTearDown]
     public IEnumerator TearDown()
     {
-        Destroy(widePlatform);
+        GameObject.DestroyImmediate(widePlatform);
         ReupSceneInstantiator.DestroySceneObjects(sceneObjects);
         yield return null;
     }

--- a/Tests/PlayMode/MaterialChangerTest.cs
+++ b/Tests/PlayMode/MaterialChangerTest.cs
@@ -10,18 +10,32 @@ public class MaterialChangerTest : MonoBehaviour
 {
     IMaterialChanger changer;
 
+    GameObject obj0;
+    GameObject obj1;
+    GameObject obj2;
+
     [SetUp]
     public void SetUp()
     {
+        obj0 = new GameObject();
+        obj0.AddComponent<MeshRenderer>();
+        obj1 = new GameObject();
+        obj1.AddComponent<MeshRenderer>();
+        obj2 = new GameObject();
         changer = new MaterialChanger();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        GameObject.DestroyImmediate(obj0);
+        GameObject.DestroyImmediate(obj1);
+        GameObject.DestroyImmediate(obj2);
     }
 
     [UnityTest]
     public IEnumerator ChangeMaterialOfOneObjectShouldSuccess()
     {
-        var obj0 = new GameObject();
-        obj0.AddComponent<MeshRenderer>();
-
         var materialToSelect = new Material(Shader.Find("Standard"));
 
         Assert.AreNotEqual(materialToSelect, obj0.GetComponent<Renderer>().sharedMaterial);
@@ -35,11 +49,6 @@ public class MaterialChangerTest : MonoBehaviour
     [UnityTest]
     public IEnumerator ChangeMaterialOfSeveralObjectsShouldSuccess()
     {
-        var obj0 = new GameObject();
-        obj0.AddComponent<MeshRenderer>();
-        var obj1 = new GameObject();
-        obj1.AddComponent<MeshRenderer>();
-
         var materialToSelect = new Material(Shader.Find("Standard"));
 
         var objectsList = new List<GameObject>() { obj0, obj1 };
@@ -62,13 +71,12 @@ public class MaterialChangerTest : MonoBehaviour
     [UnityTest]
     public IEnumerator ChangeMaterialOfObjectWithoutRendererShouldFail()
     {
-        var obj0 = new GameObject();
 
         var materialToSelect = new Material(Shader.Find("Standard"));
 
 
         Assert.That(
-            () => changer.SetNewMaterialToObjects(new List<GameObject>() { obj0 }, new int[1] { 0 }, materialToSelect),
+            () => changer.SetNewMaterialToObjects(new List<GameObject>() { obj2 }, new int[1] { 0 }, materialToSelect),
             Throws.TypeOf<Exception>()
          );
 

--- a/Tests/PlayMode/MaterialScalerTest.cs
+++ b/Tests/PlayMode/MaterialScalerTest.cs
@@ -12,6 +12,7 @@ namespace ReupVirtualTwinTests.helpers
         GameObject wallPrefabInCm = AssetDatabase.LoadAssetAtPath<GameObject>("Packages/com.reup.romulo/Tests/TestAssets/150cmx150cm_inclined_texture_10cmx14cm.prefab");
         GameObject wallInstanceInM;
         GameObject wallInstanceInCm;
+        GameObject testObj;
         MaterialScaler materialScaler;
         Vector2 originalTextureDimensionsInMillimeters;
         Vector2 desiredTextureDimensionsInM;
@@ -28,12 +29,14 @@ namespace ReupVirtualTwinTests.helpers
             desiredTextureDimensionsInM = new Vector2(originalTextureDimensionsInMillimeters.x * xScale, originalTextureDimensionsInMillimeters.y * yScale);
             expectedMaterialScale = new Vector2(1 / xScale, 1 / yScale);
             materialScaler = new MaterialScaler();
+            testObj = new GameObject();
         }
         [TearDown]
         public void TearDown()
         {
-            GameObject.Destroy(wallInstanceInCm);
-            GameObject.Destroy(wallInstanceInM);
+            GameObject.DestroyImmediate(wallInstanceInCm);
+            GameObject.DestroyImmediate(wallInstanceInM);
+            GameObject.DestroyImmediate(testObj);
         }
 
         [Test]
@@ -55,10 +58,9 @@ namespace ReupVirtualTwinTests.helpers
         [Test]
         public void ShouldAdjustUVScaleToDimensions_while_selecting_non_collinear_triangle()
         {
-            GameObject wall = new GameObject();
-            MeshRenderer meshRenderer = wall.AddComponent<MeshRenderer>();
+            MeshRenderer meshRenderer = testObj.AddComponent<MeshRenderer>();
             meshRenderer.sharedMaterial = new Material(Shader.Find("Universal Render Pipeline/Lit")); ;
-            MeshFilter meshFilter = wall.AddComponent<MeshFilter>();
+            MeshFilter meshFilter = testObj.AddComponent<MeshFilter>();
             Mesh mesh = new Mesh();
             mesh.vertices = new Vector3[] {
                 new Vector3(0,0,0), new Vector3(0,0.5f,0), new Vector3(0,1,0), // 3 points in the same line (same 3 points of first triangle)
@@ -75,18 +77,17 @@ namespace ReupVirtualTwinTests.helpers
                 2, 3, 4,
             };
             meshFilter.sharedMesh = mesh;
-            materialScaler.AdjustUVScaleToDimensions(wall, new Vector2(2000, 2000));
-            Material material = wall.GetComponent<Renderer>().material;
+            materialScaler.AdjustUVScaleToDimensions(testObj, new Vector2(2000, 2000));
+            Material material = testObj.GetComponent<Renderer>().material;
             AssertUtils.AssertVectorsAreEqual(new Vector2(0.5f, 0.5f), material.mainTextureScale);
         }
 
         [Test]
         public void ShouldAdjustUVScaleToDimensions_withTrianglesIndexesNotFollowingAnyOrder()
         {
-            GameObject wall = new GameObject();
-            MeshRenderer meshRenderer = wall.AddComponent<MeshRenderer>();
+            MeshRenderer meshRenderer = testObj.AddComponent<MeshRenderer>();
             meshRenderer.sharedMaterial = new Material(Shader.Find("Universal Render Pipeline/Lit")); ;
-            MeshFilter meshFilter = wall.AddComponent<MeshFilter>();
+            MeshFilter meshFilter = testObj.AddComponent<MeshFilter>();
             Mesh mesh = new Mesh();
             mesh.vertices = new Vector3[] {
                 new Vector3(0,0,0),
@@ -102,18 +103,17 @@ namespace ReupVirtualTwinTests.helpers
                 2,0,1
             };
             meshFilter.sharedMesh = mesh;
-            materialScaler.AdjustUVScaleToDimensions(wall, new Vector2(2000, 2000));
-            Material material = wall.GetComponent<Renderer>().material;
+            materialScaler.AdjustUVScaleToDimensions(testObj, new Vector2(2000, 2000));
+            Material material = testObj.GetComponent<Renderer>().material;
             AssertUtils.AssertVectorsAreEqual(new Vector2(0.5f, 0.5f), material.mainTextureScale);
         }
 
         [Test]
         public void ShouldAdjustUVScaleToDimensions_even_when_infinitesimalArePresentUVOr3DPoints()
         {
-            GameObject obj = new GameObject();
-            MeshRenderer meshRenderer = obj.AddComponent<MeshRenderer>();
+            MeshRenderer meshRenderer = testObj.AddComponent<MeshRenderer>();
             meshRenderer.sharedMaterial = new Material(Shader.Find("Universal Render Pipeline/Lit")); ;
-            MeshFilter meshFilter = obj.AddComponent<MeshFilter>();
+            MeshFilter meshFilter = testObj.AddComponent<MeshFilter>();
             Mesh mesh = new Mesh();
             mesh.vertices = new Vector3[] {
                 new Vector3(-14.1f, 2.9f,  0.12f),
@@ -129,18 +129,17 @@ namespace ReupVirtualTwinTests.helpers
                 0, 1, 2,
             };
             meshFilter.sharedMesh = mesh;
-            materialScaler.AdjustUVScaleToDimensions(obj, new Vector2(2000, 2000));
-            Material material = obj.GetComponent<Renderer>().material;
+            materialScaler.AdjustUVScaleToDimensions(testObj, new Vector2(2000, 2000));
+            Material material = testObj.GetComponent<Renderer>().material;
             AssertUtils.AssertVectorsAreEqual(new Vector2(1.196138f, 6.66403f), material.mainTextureScale);
         }
 
         [Test]
         public void ShouldMakeSureUVcoordinatesAreNotCollinear()
         {
-            GameObject wall = new GameObject();
-            MeshRenderer meshRenderer = wall.AddComponent<MeshRenderer>();
+            MeshRenderer meshRenderer = testObj.AddComponent<MeshRenderer>();
             meshRenderer.sharedMaterial = new Material(Shader.Find("Universal Render Pipeline/Lit")); ;
-            MeshFilter meshFilter = wall.AddComponent<MeshFilter>();
+            MeshFilter meshFilter = testObj.AddComponent<MeshFilter>();
             Mesh mesh = new Mesh();
             mesh.vertices = new Vector3[] {
                 new Vector3(0,0,0),
@@ -159,8 +158,8 @@ namespace ReupVirtualTwinTests.helpers
                 1, 2, 3, // this triangle is the one that should be used to calculate the texture dimensions
             };
             meshFilter.sharedMesh = mesh;
-            materialScaler.AdjustUVScaleToDimensions(wall, new Vector2(2000, 2000));
-            Material material = wall.GetComponent<Renderer>().material;
+            materialScaler.AdjustUVScaleToDimensions(testObj, new Vector2(2000, 2000));
+            Material material = testObj.GetComponent<Renderer>().material;
             AssertUtils.AssertVectorsAreEqual(new Vector2(0.5f, 0.5f), material.mainTextureScale);
         }
 

--- a/Tests/PlayMode/ModelInfoManagerTest.cs
+++ b/Tests/PlayMode/ModelInfoManagerTest.cs
@@ -36,6 +36,7 @@ public class ModelInfoManagerTest : MonoBehaviour
         ReupSceneInstantiator.DestroySceneObjects(sceneObjects);
         SpaceSelectorFabric.DestroySpaceSelectors(spaceSelectors);
         spaceSelectors?.Clear();
+        GameObject.DestroyImmediate(buildingGameObject);
         yield return null;
     }
 

--- a/Tests/PlayMode/ObjectInfoTest.cs
+++ b/Tests/PlayMode/ObjectInfoTest.cs
@@ -11,6 +11,7 @@ namespace ReupVirtualTwinTests.models
     public class ObjectInfoTest : MonoBehaviour
     {
         GameObject testObj;
+        GameObject testObjWithMaterial;
         ObjectInfo objectInfo;
 
         [SetUp]
@@ -18,12 +19,14 @@ namespace ReupVirtualTwinTests.models
         {
             testObj = new GameObject("testObj");
             objectInfo = testObj.AddComponent<ObjectInfo>();
+            testObjWithMaterial = new GameObject("testObjWithMaterial");
         }
 
         [TearDown]
         public void TearDown()
         {
-            Destroy(testObj);
+            GameObject.DestroyImmediate(testObj);
+            GameObject.DestroyImmediate(testObjWithMaterial);
         }
 
         [UnityTest]
@@ -35,7 +38,6 @@ namespace ReupVirtualTwinTests.models
         [UnityTest]
         public IEnumerator ShouldAddOriginalMaterialToObjectInfoOnInit_if_objectHasMaterial()
         {
-            GameObject testObjWithMaterial = new GameObject("testObjWithMaterial");
             Material dummyMaterial = new Material(Shader.Find("Universal Render Pipeline/Lit"));
             dummyMaterial.name = "my dummy material";
             testObjWithMaterial.AddComponent<MeshRenderer>().sharedMaterial = dummyMaterial;

--- a/Tests/PlayMode/ObjectMapperTest.cs
+++ b/Tests/PlayMode/ObjectMapperTest.cs
@@ -25,7 +25,7 @@ public class ObjectMapperTest : MonoBehaviour
     [TearDown]
     public void TearDown()
     {
-        Destroy(mockBuilding);
+        GameObject.DestroyImmediate(mockBuilding);
     }
 
     [UnityTest]

--- a/Tests/PlayMode/ObjectPoolTest.cs
+++ b/Tests/PlayMode/ObjectPoolTest.cs
@@ -29,9 +29,14 @@ public class ObjectPoolTest
     [TearDown]
     public void TearDown()
     {
-        UnityEngine.Object.Destroy(obj);
-        UnityEngine.Object.Destroy(parentObject);
-        UnityEngine.Object.Destroy(prefab);
+        GameObject.DestroyImmediate(obj);
+        GameObject.DestroyImmediate(pool.gameObject);
+        GameObject.DestroyImmediate(parentObject);
+        GameObject.DestroyImmediate(prefab);
+        foreach (var obj in pool.prefabsForPool)
+        {
+            GameObject.DestroyImmediate(obj);
+        }
     }
 
     [UnityTest]
@@ -59,9 +64,8 @@ public class ObjectPoolTest
     [UnityTest]
     public IEnumerator Unpool_pool_newObject_should_success()
     {
-
         //create prefabInstance
-        var prefabInstance = pool.GetObjectFromPool(prefab.name, parentObject.transform);
+        GameObject prefabInstance = pool.GetObjectFromPool(prefab.name, parentObject.transform);
 
         //check prefabInstance's parent
         Assert.AreEqual(parentObject, prefabInstance.transform.parent.gameObject);
@@ -79,7 +83,7 @@ public class ObjectPoolTest
         Assert.IsFalse(prefabInstance.activeSelf);
 
         //unpool object again
-        var prefabInstance2 = pool.GetObjectFromPool(prefab.name);
+        GameObject prefabInstance2 = pool.GetObjectFromPool(prefab.name);
 
         //check prefabInstance is active
         Assert.IsTrue(prefabInstance.activeSelf);
@@ -87,11 +91,10 @@ public class ObjectPoolTest
         Assert.AreEqual(prefabInstance, prefabInstance2);
 
         //create another prefabInstance
-        var prefabInstance3 = pool.GetObjectFromPool(prefab.name, parentObject.transform);
+        GameObject prefabInstance3 = pool.GetObjectFromPool(prefab.name, parentObject.transform);
 
         //check prefabInstance3 is indeed a new gameobject
         Assert.AreNotEqual(prefabInstance, prefabInstance3);
-            
         yield return null;
     }
 }

--- a/Tests/PlayMode/ObjectTagsTest.cs
+++ b/Tests/PlayMode/ObjectTagsTest.cs
@@ -23,7 +23,7 @@ public class ObjectTagsTest : MonoBehaviour
     [TearDown]
     public void TearDown()
     {
-        Destroy(containerGameObject);
+        GameObject.DestroyImmediate(containerGameObject);
     }
     [UnityTest]
     public IEnumerator ShouldInitializeWithEmptyTagsList()

--- a/Tests/PlayMode/ObjectWrapperTest.cs
+++ b/Tests/PlayMode/ObjectWrapperTest.cs
@@ -28,9 +28,10 @@ public class ObjectWrapperTest : MonoBehaviour
     [TearDown]
     public void TearDown()
     {
-        Destroy(obj0);
-        Destroy(obj1);
-        Destroy(originalParent);
+        GameObject.DestroyImmediate(obj0);
+        GameObject.DestroyImmediate(obj1);
+        GameObject.DestroyImmediate(originalParent);
+        GameObject.DestroyImmediate(objectWrapper.wrapper);
     }
 
     [UnityTest]

--- a/Tests/PlayMode/OriginalSceneControllerTest.cs
+++ b/Tests/PlayMode/OriginalSceneControllerTest.cs
@@ -41,6 +41,9 @@ namespace ReupVirtualTwinTests.controllers
         {
             objectRegistry.ClearRegistry();
             ReupSceneInstantiator.DestroySceneObjects(sceneObjects);
+            GameObject.DestroyImmediate(object1);
+            GameObject.DestroyImmediate(object2);
+            GameObject.DestroyImmediate(objectWithNoMaterial);
             yield return null;
         }
 

--- a/Tests/PlayMode/RegisteredIdentifierTest.cs
+++ b/Tests/PlayMode/RegisteredIdentifierTest.cs
@@ -28,7 +28,8 @@ namespace ReupVirtualTwinTests.Registry
         [UnityTearDown]
         public IEnumerator TearDownCoroutine()
         {
-            Destroy(testObj0);
+            GameObject.DestroyImmediate(testObj0);
+            GameObject.DestroyImmediate(testObj1);
             objectRegistry.ClearRegistry();
             ReupSceneInstantiator.DestroySceneObjects(sceneObjects);
             yield return null;
@@ -85,22 +86,22 @@ namespace ReupVirtualTwinTests.Registry
         [UnityTest]
         public IEnumerator ShoulBeAbleToGenerateIdRightAfterCreatingTheUniqueIdComponent()
         {
-            GameObject gameObject = new GameObject("new-game-obj");
-            RegisteredIdentifier registeredIdentifier = gameObject.AddComponent<RegisteredIdentifier>();
+            testObj0 = new GameObject("new-game-obj");
+            RegisteredIdentifier registeredIdentifier = testObj0.AddComponent<RegisteredIdentifier>();
             yield return null;
             Assert.IsNotNull(registeredIdentifier.getId());
-            Assert.AreEqual(gameObject, objectRegistry.GetObjectWithGuid(registeredIdentifier.getId()));
+            Assert.AreEqual(testObj0, objectRegistry.GetObjectWithGuid(registeredIdentifier.getId()));
             yield return null;
         }
         [UnityTest]
         public IEnumerator ShoulBeAbleToAssignIdRightAfterCreatingTheUniqueIdComponent()
         {
-            GameObject gameObject = new GameObject("new-game-obj");
-            RegisteredIdentifier registeredIdentifier = gameObject.AddComponent<RegisteredIdentifier>();
+            testObj0 = new GameObject("new-game-obj");
+            RegisteredIdentifier registeredIdentifier = testObj0.AddComponent<RegisteredIdentifier>();
             string assignedId = "assigned-id";
             registeredIdentifier.AssignId(assignedId);
             Assert.IsNotNull(registeredIdentifier.getId());
-            Assert.AreEqual(gameObject, objectRegistry.GetObjectWithGuid(assignedId));
+            Assert.AreEqual(testObj0, objectRegistry.GetObjectWithGuid(assignedId));
             yield return null;
         }
 

--- a/Tests/PlayMode/SelectedObjectsManagerTest.cs
+++ b/Tests/PlayMode/SelectedObjectsManagerTest.cs
@@ -25,7 +25,7 @@ public class SelectedObjectsManagerTest : MonoBehaviour
     ObjectHighlighterSpy mockHighlighter;
     MockObjectWrapper mockObjectWrapper;
     ITagsController tagsController;
-    HighlightAnimatorMock highlighAnimatorMock;
+    HighlightAnimatorMock highlightAnimatorMock;
 
     [SetUp]
     public void SetUp()
@@ -43,17 +43,21 @@ public class SelectedObjectsManagerTest : MonoBehaviour
         selectedObjectsManager.highlighter = mockHighlighter;
         selectedObjectsManager.objectWrapper = mockObjectWrapper;
         tagsController = new TagsController();
-        highlighAnimatorMock = new HighlightAnimatorMock();
-        selectedObjectsManager.highlightAnimator = highlighAnimatorMock;
+        highlightAnimatorMock = new HighlightAnimatorMock();
+        selectedObjectsManager.highlightAnimator = highlightAnimatorMock;
         selectedObjectsManager.tagsController = tagsController;
     }
 
     [TearDown]
     public void TearDown()
     {
-        Destroy(containerGameObject);
-        Destroy(testGameObject0);
-        Destroy(testGameObject1);
+        mockHighlighter.DestroyTestObjects();
+        mockObjectWrapper.DestroyTestObjects();
+        mockMediator.DestroyTestObjects();
+        highlightAnimatorMock.DestroyTestObjects();
+        GameObject.DestroyImmediate(containerGameObject);
+        GameObject.DestroyImmediate(testGameObject0);
+        GameObject.DestroyImmediate(testGameObject1);
     }
 
 
@@ -171,11 +175,12 @@ public class SelectedObjectsManagerTest : MonoBehaviour
         tagsController.AddTagToObject(objectRegistry.objects[3], EditionTagsCreator.CreateSelectableTag());
         yield return null;
         selectedObjectsManager.HighlightSelectableObjects();
-        Assert.AreEqual(highlighAnimatorMock.requestedGameObjectsList.Count, 1);
+        Assert.AreEqual(highlightAnimatorMock.requestedGameObjectsList.Count, 1);
         Assert.AreEqual(
-            highlighAnimatorMock.requestedGameObjectsList[0],
+            highlightAnimatorMock.requestedGameObjectsList[0],
             new List<GameObject> { objectRegistry.objects[0], objectRegistry.objects[1], objectRegistry.objects[3] }
         );
+        objectRegistry.DestroyTestObjects();
     }
     private class MockMediator : IMediator
     {
@@ -193,6 +198,11 @@ public class SelectedObjectsManagerTest : MonoBehaviour
                 selectedObjects = ((ObjectWrapperDTO)(object)payload).wrappedObjects;
                 selectedObjectModified = true;
             }
+        }
+
+        public void DestroyTestObjects()
+        {
+            selectedObjects.Clear();
         }
     }
 
@@ -230,6 +240,12 @@ public class SelectedObjectsManagerTest : MonoBehaviour
             }
             return _wrapper;
         }
+
+        public void DestroyTestObjects()
+        {
+            GameObject.DestroyImmediate(_wrapper);
+            selectedObjects.Clear();
+        }
     }
 
     class HighlightAnimatorMock : IHighlightAnimator
@@ -238,6 +254,10 @@ public class SelectedObjectsManagerTest : MonoBehaviour
         public void HighlighObjectsEaseInEaseOut(List<GameObject> objs)
         {
             requestedGameObjectsList.Add(objs);
+        }
+        public void DestroyTestObjects()
+        {
+            requestedGameObjectsList.Clear();
         }
     }
 

--- a/Tests/PlayMode/SphereMaterialContainerHandlerTest.cs
+++ b/Tests/PlayMode/SphereMaterialContainerHandlerTest.cs
@@ -50,8 +50,8 @@ public class SphereMaterialContainerHandlerTest
     [UnityTearDown]
     public IEnumerator TearDownCoroutine()
     {
-        Object.Destroy(extensionSceneTriggers);
-        Object.Destroy(triggerObject);
+        GameObject.DestroyImmediate(extensionSceneTriggers);
+        GameObject.DestroyImmediate(triggerObject);
         ReupSceneInstantiator.DestroySceneObjects(sceneObjects);
         yield return null;
     }

--- a/Tests/PlayMode/TexturesManagerTest.cs
+++ b/Tests/PlayMode/TexturesManagerTest.cs
@@ -31,6 +31,8 @@ namespace ReupVirtualTwinTests.managers
         public IEnumerator TearDown()
         {
             ReupSceneInstantiator.DestroySceneObjects(sceneObjects);
+            GameObject.DestroyImmediate(cube0);
+            GameObject.DestroyImmediate(cube1);
             yield return null;
         }
 

--- a/Tests/PlayMode/TransformObjectsManagerTest.cs
+++ b/Tests/PlayMode/TransformObjectsManagerTest.cs
@@ -23,6 +23,7 @@ public class TransformObjectsManagerTest : MonoBehaviour
     GameObject transformableObject0;
     GameObject transformableObject1;
     GameObject nonTransformableObject;
+    GameObject mockWrapper;
 
     [SetUp]
     public void SetUp()
@@ -42,6 +43,19 @@ public class TransformObjectsManagerTest : MonoBehaviour
         transformableObject1.AddComponent<ObjectTags>().AddTags(new Tag[2] {EditionTagsCreator.CreateSelectableTag(), EditionTagsCreator.CreateTransformableTag()});
         nonTransformableObject = new GameObject("nonTransformableObject");
         nonTransformableObject.AddComponent<ObjectTags>().AddTags(new Tag[1] {EditionTagsCreator.CreateSelectableTag()});
+        mockWrapper = new GameObject("wrapper");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        GameObject.DestroyImmediate(containerGameObject);
+        GameObject.DestroyImmediate(transformWrapper);
+        GameObject.DestroyImmediate(runtimeTransformObj);
+        GameObject.DestroyImmediate(transformableObject0);
+        GameObject.DestroyImmediate(transformableObject1);
+        GameObject.DestroyImmediate(nonTransformableObject);
+        GameObject.DestroyImmediate(mockWrapper);
     }
 
     [UnityTest]
@@ -148,7 +162,7 @@ public class TransformObjectsManagerTest : MonoBehaviour
     {
         ObjectWrapperDTO objectWrapperDTO = new ObjectWrapperDTO()
         {
-            wrapper = new GameObject("wrapper"),
+            wrapper = mockWrapper,
             wrappedObjects = new List<GameObject>() { transformableObject0, transformableObject1},
         };
         transformObjectsManager.ActivateTransformMode(objectWrapperDTO, TransformMode.PositionMode);
@@ -166,7 +180,7 @@ public class TransformObjectsManagerTest : MonoBehaviour
     {
         ObjectWrapperDTO objectWrapperDTO = new ObjectWrapperDTO()
         {
-            wrapper = new GameObject("wrapper"),
+            wrapper = mockWrapper,
             wrappedObjects = new List<GameObject>() { transformableObject0, transformableObject1, nonTransformableObject }
         };
         transformObjectsManager.ActivateTransformMode(objectWrapperDTO, TransformMode.PositionMode);
@@ -180,7 +194,7 @@ public class TransformObjectsManagerTest : MonoBehaviour
     {
         ObjectWrapperDTO objectWrapperDTO = new ObjectWrapperDTO()
         {
-            wrapper = new GameObject("wrapper"),
+            wrapper = mockWrapper,
             wrappedObjects = new List<GameObject>() { transformableObject0, transformableObject1, nonTransformableObject }
         };
         transformObjectsManager.ActivateTransformMode(objectWrapperDTO, TransformMode.RotationMode);

--- a/Tests/PlayMode/UniqueIdTest.cs
+++ b/Tests/PlayMode/UniqueIdTest.cs
@@ -21,7 +21,7 @@ public class UniqueIdTest : MonoBehaviour
     [TearDown]
     public void TearDown()
     {
-        Destroy(testObj);
+        GameObject.DestroyImmediate(testObj);
     }
 
     [UnityTest]

--- a/Tests/TestMocks/ObjectHighlighterSpy.cs
+++ b/Tests/TestMocks/ObjectHighlighterSpy.cs
@@ -40,5 +40,13 @@ namespace ReupVirtualTwinTests.mocks
             HighlightObject(obj);
             return true;
         }
+
+        public void DestroyTestObjects()
+        {
+            if (highlightedObject != null)
+            {
+                GameObject.DestroyImmediate(highlightedObject);
+            }
+        }
     }
 }

--- a/Tests/TestMocks/ObjectRegistrySpy.cs
+++ b/Tests/TestMocks/ObjectRegistrySpy.cs
@@ -89,5 +89,13 @@ namespace ReupVirtualTwinTests.mocks
         {
             return objects.ConvertAll(obj => obj.GetComponent<IUniqueIdentifier>().getId()).ToArray();
         }
+
+        public void DestroyTestObjects()
+        {
+            foreach (GameObject obj in objects)
+            {
+                GameObject.DestroyImmediate(obj);
+            }
+        }
     }
 }

--- a/Tests/TestUtils/ReupSceneInstantiator.cs
+++ b/Tests/TestUtils/ReupSceneInstantiator.cs
@@ -114,7 +114,6 @@ namespace ReupVirtualTwinTests.utils
 
             SpacesRecord spacesRecord = baseGlobalScriptGameObject.transform.Find("SpacesRecord").GetComponent<SpacesRecord>();
 
-            MoveDhvCamera moveDhvCamera = dollhouseViewWrapper.GetComponent<MoveDhvCamera>();
             MoveDhvCamera moveDhvCameraBehavior = dollhouseViewWrapper.GetComponent<MoveDhvCamera>();
 
             ZoomDhvCamera zoomDhvCameraBehavior = dollhouseViewWrapper.GetComponent<ZoomDhvCamera>();


### PR DESCRIPTION
[Reup-447](https://macheight-reup.atlassian.net/browse/REUP-447)

As a developer, I want to destroy all gameobjects created while testing in unity, so tests are properly isolated from one another.

AC:

All objects created during tests are destroyed after each test that create it