### PR TITLE
Reup459 make receive method a sync method

### DIFF
--- a/Runtime/BehavioursInterfaces/IWebMessageReceiver.cs
+++ b/Runtime/BehavioursInterfaces/IWebMessageReceiver.cs
@@ -4,6 +4,6 @@ namespace ReupVirtualTwin.behaviourInterfaces
 {
     public interface IWebMessageReceiver
     {
-        public Task ReceiveWebMessage(string serializedWebMessage);
+        public void ReceiveWebMessage(string serializedWebMessage);
     }
 }

--- a/Runtime/Managers/EditMediator.cs
+++ b/Runtime/Managers/EditMediator.cs
@@ -189,7 +189,7 @@ namespace ReupVirtualTwin.managers
             }
         }
 
-        public async Task ReceiveWebMessage(string serializedWebMessage)
+        public void ReceiveWebMessage(string serializedWebMessage)
         {
             JObject message = JObject.Parse(serializedWebMessage);
             IList<string> errorMessages;
@@ -204,6 +204,11 @@ namespace ReupVirtualTwin.managers
             }
             string type = message["type"].ToString();
             JToken payload = message["payload"];
+            ReceiveWebMessage(type, payload);
+        }
+
+        public async Task ReceiveWebMessage(string type, JToken payload)
+        {
             try
             {
                 await ExecuteWebMessage(type, payload);

--- a/Tests/PlayMode/EditMediatorTest.cs
+++ b/Tests/PlayMode/EditMediatorTest.cs
@@ -661,7 +661,7 @@ public class EditMediatorTest : MonoBehaviour
         );
 
         string serializedMessage = JsonConvert.SerializeObject(requestSceneLoadMessage);
-        await editMediator.ReceiveWebMessage(serializedMessage);
+        editMediator.ReceiveWebMessage(serializedMessage);
 
         WebMessage<JObject> sentMessage = (WebMessage<JObject>)mockWebMessageSender.sentMessages[0];
 
@@ -698,7 +698,7 @@ public class EditMediatorTest : MonoBehaviour
 
         changeMaterialControllerSpy.throwError = true;
         string serializedMessage = JsonConvert.SerializeObject(requestSceneLoadMessage);
-        await editMediator.ReceiveWebMessage(serializedMessage);
+        editMediator.ReceiveWebMessage(serializedMessage);
 
         WebMessage<JObject> sentMessage = (WebMessage<JObject>)mockWebMessageSender.sentMessages[0];
         string actualErrorMessage = sentMessage.payload["errorMessage"].ToString();
@@ -845,7 +845,7 @@ public class EditMediatorTest : MonoBehaviour
 
         changeMaterialControllerSpy.throwError = true;
         string serializedMessage = JsonConvert.SerializeObject(requesMessage);
-        await editMediator.ReceiveWebMessage(serializedMessage);
+        editMediator.ReceiveWebMessage(serializedMessage);
 
         WebMessage<JObject> sentMessage = (WebMessage<JObject>)mockWebMessageSender.sentMessages[0];
         Assert.AreEqual(WebMessageType.changeObjectsMaterialFailure, sentMessage.type);
@@ -1113,7 +1113,7 @@ public class EditMediatorTest : MonoBehaviour
             }
         );
         string serializedMessage = JsonConvert.SerializeObject(requestSceneLoadMessage);
-        await editMediator.ReceiveWebMessage(serializedMessage);
+        editMediator.ReceiveWebMessage(serializedMessage);
         JObject expectedMaterialChangeRequest = new JObject
         {
             { "material", material },
@@ -1164,7 +1164,7 @@ public class EditMediatorTest : MonoBehaviour
             }
         );
         string serializedMessage = JsonConvert.SerializeObject(requestSceneLoadMessage);
-        await editMediator.ReceiveWebMessage(serializedMessage);
+        editMediator.ReceiveWebMessage(serializedMessage);
 
         JObject[] expectedMaterialChangeRequests = new JObject[]
         {
@@ -1212,7 +1212,7 @@ public class EditMediatorTest : MonoBehaviour
             }
         );
         string serializedMessage = JsonConvert.SerializeObject(requestSceneLoadMessage);
-        await editMediator.ReceiveWebMessage(serializedMessage);
+        editMediator.ReceiveWebMessage(serializedMessage);
         WebMessage<JObject> sentMessage = (WebMessage<JObject>)mockWebMessageSender.sentMessages[0];
         Assert.AreEqual(1, mockWebMessageSender.sentMessages.Count);
         Assert.AreEqual(WebMessageType.requestSceneLoadSuccess, sentMessage.type);
@@ -1241,7 +1241,7 @@ public class EditMediatorTest : MonoBehaviour
             }
         );
         string serializedMessage = JsonConvert.SerializeObject(requestSceneLoadMessage);
-        await editMediator.ReceiveWebMessage(serializedMessage);
+        editMediator.ReceiveWebMessage(serializedMessage);
         Assert.AreEqual(1, mockWebMessageSender.sentMessages.Count);
         Assert.AreEqual(0, changeColorManagerSpy.calledColors.Count);
         Assert.AreEqual(0, changeMaterialControllerSpy.receivedMessageRequests.Count);
@@ -1253,7 +1253,7 @@ public class EditMediatorTest : MonoBehaviour
         requestSceneLoadMessage["payload"]["objects"] = new JArray();
         string serializedMessage = JsonConvert.SerializeObject(requestSceneLoadMessage);
         Assert.AreEqual(0, originalSceneControllerSpy.restoreOriginalSceneCallsCount);
-        await editMediator.ReceiveWebMessage(serializedMessage);
+        editMediator.ReceiveWebMessage(serializedMessage);
         Assert.AreEqual(1, originalSceneControllerSpy.restoreOriginalSceneCallsCount);
     }
 

--- a/Tests/PlayMode/SlideToSpaceTest.cs
+++ b/Tests/PlayMode/SlideToSpaceTest.cs
@@ -107,7 +107,7 @@ namespace ReupVirtualTwinTests.generalTests
                 })
             };
             yield return null;
-            yield return editMediator.ReceiveWebMessage(serializedMessage);
+            editMediator.ReceiveWebMessage(serializedMessage);
             yield return new WaitForSeconds(0.3f);
             Vector3 desiredPositionAfterJump = new Vector3(spaceJumpPointPosition.x, characterYPosition, spaceJumpPointPosition.z);
             AssertUtils.AssertVectorsAreClose(desiredPositionAfterJump, character.position, 0.02);
@@ -126,7 +126,7 @@ namespace ReupVirtualTwinTests.generalTests
                 })
             };
             yield return null;
-            yield return editMediator.ReceiveWebMessage(serializedMessage);
+            editMediator.ReceiveWebMessage(serializedMessage);
             yield return new WaitForSeconds(0.3f);
             Assert.AreEqual(1, webMessageSenderSpy.sentMessages.Count);
             WebMessage<JObject> sentMessage = (WebMessage<JObject>)webMessageSenderSpy.sentMessages[0];
@@ -157,7 +157,8 @@ namespace ReupVirtualTwinTests.generalTests
                     }
                 }
             };
-            yield return editMediator.ReceiveWebMessage(JsonConvert.SerializeObject(message));
+            editMediator.ReceiveWebMessage(JsonConvert.SerializeObject(message));
+            yield return null;
             Assert.AreEqual(1, webMessageSenderSpy.sentMessages.Count);
             WebMessage<JObject> sentMessage = (WebMessage<JObject>)webMessageSenderSpy.sentMessages[0];
             WebMessage<JObject> expectedMessage = new WebMessage<JObject>
@@ -185,7 +186,7 @@ namespace ReupVirtualTwinTests.generalTests
                 })
             };
             spaceSelectors[0].transform.position = new Vector3(100, 100, 100);
-            yield return editMediator.ReceiveWebMessage(serializedMessage);
+            editMediator.ReceiveWebMessage(serializedMessage);
             Assert.AreEqual(1, webMessageSenderSpy.sentMessages.Count);
             WebMessage<JObject> sentMessage = (WebMessage<JObject>)webMessageSenderSpy.sentMessages[0];
             WebMessage<JObject> expectedMessage = new WebMessage<JObject>


### PR DESCRIPTION
[Reup459](https://macheight-reup.atlassian.net/browse/REUP-459?atlOrigin=eyJpIjoiMmVlYmFhZjM5YzVmNDE4Yjg2NzMxODY0YjQ5OGU2M2UiLCJwIjoiaiJ9)

As a developer, I want the ReceiveWebMessage method in unity not to be an async method, so my log console is not flooded with warning messages thus making it easier for me to debug real problems.

AC:

The ReceiveWebMessage is not an async method.

