### PR TITLE
Reup-409 Rotate Dhv with multi touch gesture

### DIFF
--- a/Assets/Quickstart/Reup.prefab
+++ b/Assets/Quickstart/Reup.prefab
@@ -1585,6 +1585,7 @@ GameObject:
   - component: {fileID: 5049356630348509960}
   - component: {fileID: 2229151576000372229}
   - component: {fileID: 635520396724393132}
+  - component: {fileID: 7447753011683123804}
   m_Layer: 0
   m_Name: DollhouseViewWrapper
   m_TagString: Untagged
@@ -1660,6 +1661,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   dollhouseViewWrapper: {fileID: 2471139282865268767}
   keyboardRotationSpeedDegreesPerSecond: 80
+  maxVerticalAngle: 89.9
+  minVerticalAngle: 10
 --- !u!114 &635520396724393132
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1673,6 +1676,23 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   dollhouseViewWrapper: {fileID: 2471139282865268767}
+  maxVerticalAngle: 89.9
+  minVerticalAngle: 10
+--- !u!114 &7447753011683123804
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4327920938282454304}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95e1c10f2c75e8c47b213088dc4b77a1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  dollhouseViewWrapper: {fileID: 2471139282865268767}
+  maxVerticalAngle: 89.9
+  minVerticalAngle: 10
 --- !u!1 &5184782299159025455
 GameObject:
   m_ObjectHideFlags: 0

--- a/Runtime/Behaviours/RotateDhvCameraKeyboard.cs
+++ b/Runtime/Behaviours/RotateDhvCameraKeyboard.cs
@@ -1,3 +1,4 @@
+using ReupVirtualTwin.enums;
 using ReupVirtualTwin.inputs;
 using UnityEngine;
 using Zenject;
@@ -8,25 +9,18 @@ namespace ReupVirtualTwin.behaviours
     {
         [SerializeField] public Transform dollhouseViewWrapper;
         [SerializeField] public float keyboardRotationSpeedDegreesPerSecond = 80f;
-        [SerializeField] public float maxVerticalAngle = 89.9f;
-        [SerializeField] public float minVerticalAngle = 10f;
 
-        private InputProvider _inputProvider;
+        private InputProvider inputProvider;
 
         [Inject]
         public void Init(InputProvider inputProvider)
         {
-            _inputProvider = inputProvider;
+            this.inputProvider = inputProvider;
         }
 
         private void Update()
         {
-            UpdateCameraRotationWithKeyboard();
-        }
-
-        private void UpdateCameraRotationWithKeyboard()
-        {
-            Vector2 rotationDirection = _inputProvider.KeyboardRotateDhvCamera();
+            Vector2 rotationDirection = inputProvider.KeyboardRotateDhvCamera();
             if (rotationDirection == Vector2.zero)
             {
                 return;
@@ -34,7 +28,7 @@ namespace ReupVirtualTwin.behaviours
             float deltaSpeed = keyboardRotationSpeedDegreesPerSecond * Time.deltaTime;
             float horizontalRotation = dollhouseViewWrapper.localEulerAngles.y - (rotationDirection.x * deltaSpeed);
             float verticalRotation = dollhouseViewWrapper.localEulerAngles.x - (rotationDirection.y * deltaSpeed * -1);
-            verticalRotation = Mathf.Clamp(verticalRotation, minVerticalAngle, maxVerticalAngle);
+            verticalRotation = Mathf.Clamp(verticalRotation, RomuloGlobalSettings.minVerticalAngle, RomuloGlobalSettings.maxVerticalAngle);
             dollhouseViewWrapper.localEulerAngles = new Vector3(verticalRotation, horizontalRotation, 0);
         }
 

--- a/Runtime/Behaviours/RotateDhvCameraKeyboard.cs
+++ b/Runtime/Behaviours/RotateDhvCameraKeyboard.cs
@@ -8,9 +8,9 @@ namespace ReupVirtualTwin.behaviours
     {
         [SerializeField] public Transform dollhouseViewWrapper;
         [SerializeField] public float keyboardRotationSpeedDegreesPerSecond = 80f;
+        [SerializeField] public float maxVerticalAngle = 89.9f;
+        [SerializeField] public float minVerticalAngle = 10f;
 
-        private float maxVerticalAngle = 89.9f;
-        private float minVerticalAngle = 10f;
         private InputProvider _inputProvider;
 
         [Inject]

--- a/Runtime/Behaviours/RotateDhvCameraMouse.cs
+++ b/Runtime/Behaviours/RotateDhvCameraMouse.cs
@@ -8,9 +8,9 @@ namespace ReupVirtualTwin.behaviours
 {
     public class RotateDhvCameraMouse : MonoBehaviour
     {
-        [SerializeField] public Transform dollhouseViewWrapper;
-        private float maxVerticalAngle = 89.9f;
-        private float minVerticalAngle = 10f;
+        [SerializeField] public Transform dollhouseViewWrapper;        
+        [SerializeField] public float maxVerticalAngle = 89.9f;
+        [SerializeField] public float minVerticalAngle = 10f;
         InputProvider _inputProvider;
         IDragManager dragManager;
 

--- a/Runtime/Behaviours/RotateDhvCameraMouse.cs
+++ b/Runtime/Behaviours/RotateDhvCameraMouse.cs
@@ -11,6 +11,8 @@ namespace ReupVirtualTwin.behaviours
         [SerializeField] public Transform dollhouseViewWrapper;        
         [SerializeField] public float maxVerticalAngle = 89.9f;
         [SerializeField] public float minVerticalAngle = 10f;
+        [SerializeField] public float verticalRotationPerScreenHeight = 180f;
+        [SerializeField] public float horizontalRotationPerScreenWidth = 180f;
         InputProvider _inputProvider;
         IDragManager dragManager;
 
@@ -32,8 +34,8 @@ namespace ReupVirtualTwin.behaviours
         {
             Vector2 mouseDelta = _inputProvider.MouseRotateDhvCamera();
 
-            float horizontalRotation = (mouseDelta.x / Screen.width) * 180f;
-            float verticalRotation = (mouseDelta.y / Screen.height) * 180f;
+            float horizontalRotation = (mouseDelta.x / Screen.width) * horizontalRotationPerScreenWidth;
+            float verticalRotation = (mouseDelta.y / Screen.height) * verticalRotationPerScreenHeight;
 
             float currentVerticalAngle = dollhouseViewWrapper.localEulerAngles.x;
             float newVerticalAngle = Mathf.Clamp(currentVerticalAngle - verticalRotation, minVerticalAngle, maxVerticalAngle);

--- a/Runtime/Behaviours/RotateDhvCameraMouse.cs
+++ b/Runtime/Behaviours/RotateDhvCameraMouse.cs
@@ -1,3 +1,4 @@
+using ReupVirtualTwin.enums;
 using ReupVirtualTwin.helpers;
 using ReupVirtualTwin.inputs;
 using ReupVirtualTwin.managerInterfaces;
@@ -9,17 +10,13 @@ namespace ReupVirtualTwin.behaviours
     public class RotateDhvCameraMouse : MonoBehaviour
     {
         [SerializeField] public Transform dollhouseViewWrapper;        
-        [SerializeField] public float maxVerticalAngle = 89.9f;
-        [SerializeField] public float minVerticalAngle = 10f;
-        [SerializeField] public float verticalRotationPerScreenHeight = 180f;
-        [SerializeField] public float horizontalRotationPerScreenWidth = 180f;
-        InputProvider _inputProvider;
+        InputProvider inputProvider;
         IDragManager dragManager;
 
         [Inject]
         public void Init(IDragManager dragManager, InputProvider inputProvider)
         {
-            _inputProvider = inputProvider;
+            this.inputProvider = inputProvider;
             this.dragManager = dragManager;
         }
         private void Update()
@@ -32,13 +29,17 @@ namespace ReupVirtualTwin.behaviours
 
         private void UpdateCameraRotationWithMouse()
         {
-            Vector2 mouseDelta = _inputProvider.MouseRotateDhvCamera();
+            Vector2 mouseDelta = inputProvider.MouseRotateDhvCamera();
 
-            float horizontalRotation = (mouseDelta.x / Screen.width) * horizontalRotationPerScreenWidth;
-            float verticalRotation = (mouseDelta.y / Screen.height) * verticalRotationPerScreenHeight;
+            float horizontalRotation = (mouseDelta.x / Screen.width) * RomuloGlobalSettings.horizontalRotationPerScreenWidth;
+            float verticalRotation = (mouseDelta.y / Screen.height) * RomuloGlobalSettings.verticalRotationPerScreenHeight;
 
             float currentVerticalAngle = dollhouseViewWrapper.localEulerAngles.x;
-            float newVerticalAngle = Mathf.Clamp(currentVerticalAngle - verticalRotation, minVerticalAngle, maxVerticalAngle);
+            float newVerticalAngle = Mathf.Clamp(
+                currentVerticalAngle - verticalRotation, 
+                RomuloGlobalSettings.minVerticalAngle, 
+                RomuloGlobalSettings.maxVerticalAngle
+            );
 
             dollhouseViewWrapper.localEulerAngles = new Vector3(
                 newVerticalAngle,

--- a/Runtime/Behaviours/RotateDhvCameraTouch.cs
+++ b/Runtime/Behaviours/RotateDhvCameraTouch.cs
@@ -1,3 +1,4 @@
+using NUnit.Framework;
 using NUnit.Framework.Internal;
 using ReupVirtualTwin.inputs;
 using ReupVirtualTwin.managerInterfaces;
@@ -12,15 +13,22 @@ namespace ReupVirtualTwin.behaviours
         [SerializeField] public Transform dollhouseViewWrapper;
         [SerializeField] public float maxVerticalAngle = 89.9f;
         [SerializeField] public float minVerticalAngle = 10f;
+        [SerializeField] public float rotationThreshold = 2.5f;
+        [SerializeField] public float verticalRotationPerScreenHeight = 180f;
 
         InputProvider _inputProvider;
         IGesturesManager gesturesManager;
+
+        Vector2 initialTouch1Position;
+        Vector2 initialTouch2Position;
 
         Vector2 touch1Position;
         Vector2 touch2Position;
         float currentAngle;
 
         bool isInitDataSet = false;
+        bool isHorizontalRotation = false;
+        bool isVerticalRotation = false;
 
         [Inject]
         public void Init(InputProvider inputProvider, IGesturesManager gesturesManager)
@@ -36,14 +44,62 @@ namespace ReupVirtualTwin.behaviours
                 if (!isInitDataSet)
                 {
                     SetInitialData();
-                    return;
                 }
-                UpdateHorizontalCameraRotation();
-                UpdateVerticalCameraRotation();
+
+                if (!isHorizontalRotation && !isVerticalRotation)
+                {
+                    DetermineRotationType();
+                }
+
+                if (isHorizontalRotation)
+                {
+                    UpdateHorizontalCameraRotation();
+                }
+                else if (isVerticalRotation)
+                {
+                    UpdateVerticalCameraRotation();
+                }
             }
             else 
             {
-                isInitDataSet = false;
+                ResetInitialData();
+            }
+        }
+
+        private void SetInitialData()
+        {
+            initialTouch1Position = _inputProvider.Touch1Position();
+            initialTouch2Position = _inputProvider.Touch2Position();
+            touch1Position = initialTouch1Position;
+            touch2Position = initialTouch2Position;
+            currentAngle = Vector2.SignedAngle(touch2Position - touch1Position, Vector2.right);
+            isInitDataSet = true;
+        }
+
+        private void ResetInitialData()
+        {
+            isInitDataSet = false;
+            isHorizontalRotation = false;
+            isVerticalRotation = false;
+        }
+
+        private void DetermineRotationType()
+        {
+            Vector2 touch1 = _inputProvider.Touch1Position();
+            Vector2 touch2 = _inputProvider.Touch2Position();
+
+            float angleDelta = Vector2.SignedAngle(touch2 - touch1, Vector2.right) - currentAngle;
+            float newAverageY = (touch1.y + touch2.y) / 2;
+            float previousAverageY = (initialTouch1Position.y + initialTouch2Position.y) / 2;
+            float verticalDelta = newAverageY - previousAverageY;
+
+            if (Mathf.Abs(angleDelta) > rotationThreshold)
+            {
+                isHorizontalRotation = true;
+            }
+            else if (Mathf.Abs(verticalDelta) > rotationThreshold && AreTouchesMovingInSameDirection(touch1, touch2))
+            {
+                isVerticalRotation = true;
             }
         }
 
@@ -56,6 +112,7 @@ namespace ReupVirtualTwin.behaviours
             float angleDelta = newAngle - currentAngle;
 
             dollhouseViewWrapper.Rotate(Vector3.up, -angleDelta, Space.World);
+
             currentAngle = newAngle;
         }
 
@@ -64,7 +121,7 @@ namespace ReupVirtualTwin.behaviours
             Vector2 touch1 = _inputProvider.Touch1Position();
             Vector2 touch2 = _inputProvider.Touch2Position();
 
-            if (!areTouchesMovingInSameDirection(touch1, touch2))
+            if (!AreTouchesMovingInSameDirection(touch1, touch2))
             {
                 return;
             }
@@ -72,35 +129,26 @@ namespace ReupVirtualTwin.behaviours
             float newAverageY = (touch1.y + touch2.y) / 2;
             float previousAverageY = (touch1Position.y + touch2Position.y) / 2;
             float deltaY = newAverageY - previousAverageY;
-            float verticalRotation = (180f / Screen.height) * deltaY;
+            float verticalRotation = (verticalRotationPerScreenHeight / Screen.height) * deltaY;
 
             float currentVerticalAngle = dollhouseViewWrapper.localEulerAngles.x;
             float newVerticalAngle = Mathf.Clamp(currentVerticalAngle - verticalRotation, minVerticalAngle, maxVerticalAngle);
-
-            touch1Position = touch1;
-            touch2Position = touch2;
 
             dollhouseViewWrapper.localEulerAngles = new Vector3(
                 newVerticalAngle,
                 dollhouseViewWrapper.localEulerAngles.y,
                 0
             );
+
+            touch1Position = touch1;
+            touch2Position = touch2;
         }
 
-        private void SetInitialData()
-        {
-            touch1Position = _inputProvider.Touch1Position();
-            touch2Position = _inputProvider.Touch2Position();
-            currentAngle = Vector2.SignedAngle(touch2Position - touch1Position, Vector2.right);
-            isInitDataSet = true;
-        }
-
-        private bool areTouchesMovingInSameDirection(Vector2 touch1, Vector2 touch2)
+        private bool AreTouchesMovingInSameDirection(Vector2 touch1, Vector2 touch2)
         {
             bool bothMovingUp = touch1.y > touch1Position.y && touch2.y > touch2Position.y;
             bool bothMovingDown = touch1.y < touch1Position.y && touch2.y < touch2Position.y;
             return bothMovingUp || bothMovingDown;
         }
-
     }
 }

--- a/Runtime/Behaviours/RotateDhvCameraTouch.cs
+++ b/Runtime/Behaviours/RotateDhvCameraTouch.cs
@@ -1,0 +1,106 @@
+using NUnit.Framework.Internal;
+using ReupVirtualTwin.inputs;
+using ReupVirtualTwin.managerInterfaces;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using Zenject;
+
+namespace ReupVirtualTwin.behaviours
+{
+    public class RotateDhvCameraTouch : MonoBehaviour
+    {
+        [SerializeField] public Transform dollhouseViewWrapper;
+        [SerializeField] public float maxVerticalAngle = 89.9f;
+        [SerializeField] public float minVerticalAngle = 10f;
+
+        InputProvider _inputProvider;
+        IGesturesManager gesturesManager;
+
+        Vector2 touch1Position;
+        Vector2 touch2Position;
+        float currentAngle;
+
+        bool isInitDataSet = false;
+
+        [Inject]
+        public void Init(InputProvider inputProvider, IGesturesManager gesturesManager)
+        {
+            _inputProvider = inputProvider;
+            this.gesturesManager = gesturesManager;
+        }
+
+        private void Update() 
+        {
+            if (gesturesManager.gestureInProgress) 
+            {
+                if (!isInitDataSet)
+                {
+                    SetInitialData();
+                    return;
+                }
+                UpdateHorizontalCameraRotation();
+                UpdateVerticalCameraRotation();
+            }
+            else 
+            {
+                isInitDataSet = false;
+            }
+        }
+
+        private void UpdateHorizontalCameraRotation()
+        {
+            Vector2 touch1 = _inputProvider.Touch1Position();
+            Vector2 touch2 = _inputProvider.Touch2Position();
+
+            float newAngle = Vector2.SignedAngle(touch2 - touch1, Vector2.right);
+            float angleDelta = newAngle - currentAngle;
+
+            dollhouseViewWrapper.Rotate(Vector3.up, -angleDelta, Space.World);
+            currentAngle = newAngle;
+        }
+
+        private void UpdateVerticalCameraRotation()
+        {
+            Vector2 touch1 = _inputProvider.Touch1Position();
+            Vector2 touch2 = _inputProvider.Touch2Position();
+
+            if (!areTouchesMovingInSameDirection(touch1, touch2))
+            {
+                return;
+            }
+
+            float newAverageY = (touch1.y + touch2.y) / 2;
+            float previousAverageY = (touch1Position.y + touch2Position.y) / 2;
+            float deltaY = newAverageY - previousAverageY;
+            float verticalRotation = (180f / Screen.height) * deltaY;
+
+            float currentVerticalAngle = dollhouseViewWrapper.localEulerAngles.x;
+            float newVerticalAngle = Mathf.Clamp(currentVerticalAngle - verticalRotation, minVerticalAngle, maxVerticalAngle);
+
+            touch1Position = touch1;
+            touch2Position = touch2;
+
+            dollhouseViewWrapper.localEulerAngles = new Vector3(
+                newVerticalAngle,
+                dollhouseViewWrapper.localEulerAngles.y,
+                0
+            );
+        }
+
+        private void SetInitialData()
+        {
+            touch1Position = _inputProvider.Touch1Position();
+            touch2Position = _inputProvider.Touch2Position();
+            currentAngle = Vector2.SignedAngle(touch2Position - touch1Position, Vector2.right);
+            isInitDataSet = true;
+        }
+
+        private bool areTouchesMovingInSameDirection(Vector2 touch1, Vector2 touch2)
+        {
+            bool bothMovingUp = touch1.y > touch1Position.y && touch2.y > touch2Position.y;
+            bool bothMovingDown = touch1.y < touch1Position.y && touch2.y < touch2Position.y;
+            return bothMovingUp || bothMovingDown;
+        }
+
+    }
+}

--- a/Runtime/Behaviours/RotateDhvCameraTouch.cs.meta
+++ b/Runtime/Behaviours/RotateDhvCameraTouch.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 95e1c10f2c75e8c47b213088dc4b77a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Enums/RomuloGlobalSettings.cs
+++ b/Runtime/Enums/RomuloGlobalSettings.cs
@@ -1,0 +1,14 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ReupVirtualTwin.enums
+{
+    public static class RomuloGlobalSettings
+    {
+        public const float maxVerticalAngle = 89.9f;
+        public const float minVerticalAngle = 10f;
+        public const float verticalRotationPerScreenHeight = 180f;
+        public const float horizontalRotationPerScreenWidth = 180f;
+    }
+}

--- a/Runtime/Enums/RomuloGlobalSettings.cs.meta
+++ b/Runtime/Enums/RomuloGlobalSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6da03c7effadaef49852debdfc0a7c76
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Helpers/MathUtils.cs
+++ b/Runtime/Helpers/MathUtils.cs
@@ -9,6 +9,11 @@ namespace ReupVirtualTwin.helpers
             return -(((-angle + 180) % 360 + 360) % 360) + 180;
         }
 
+        public static float NormalizeTo360Degrees(float angle)
+        {
+            return ((angle % 360) + 360) % 360;
+        }
+
         public static float NormalizeAngleRad(float angle)
         {
             float pi = Mathf.PI;

--- a/Runtime/Managers/DragManager.cs
+++ b/Runtime/Managers/DragManager.cs
@@ -10,19 +10,16 @@ namespace ReupVirtualTwin.managers
 {
     public class DragManager : IDragManager, IInitializable, ITickable, IDisposable
     {
-        [HideInInspector]
         public bool primaryDragging { get; private set; } = false;
-        [HideInInspector]
         public bool secondaryDragging { get; private set; } = false;
-        [HideInInspector]
         public bool prevDragging { get; private set; } = false;
 
-        private bool _isHoldingPrimaryDrag = false;
-        private bool _isHoldingSecondaryDrag = false;
-        private Vector2 _selectPositionPrimaryDrag;
-        private Vector2 _selectPositionSecondaryDrag;
+        private bool isHoldingPrimaryDrag = false;
+        private bool isHoldingSecondaryDrag = false;
+        private Vector2 selectPositionPrimaryDrag;
+        private Vector2 selectPositionSecondaryDrag;
         private InputProvider inputProvider;
-        private float _dragDistanceThreshold = 2.0f;
+        private float dragDistanceThreshold = 2.0f;
 
         [Inject]
         public void Init(InputProvider inputProvider)
@@ -51,44 +48,44 @@ namespace ReupVirtualTwin.managers
         {
             prevDragging = primaryDragging || secondaryDragging;
             Vector2 currentPointerPosition = inputProvider.PointerInput();
-            if (_isHoldingPrimaryDrag && !primaryDragging)
+            if (isHoldingPrimaryDrag && !primaryDragging)
             {
-                primaryDragging = isDragging(currentPointerPosition, _selectPositionPrimaryDrag);
+                primaryDragging = isDragging(currentPointerPosition, selectPositionPrimaryDrag);
             }
             
-            if (_isHoldingSecondaryDrag && !secondaryDragging)
+            if (isHoldingSecondaryDrag && !secondaryDragging)
             {
-                secondaryDragging = isDragging(currentPointerPosition, _selectPositionSecondaryDrag);
+                secondaryDragging = isDragging(currentPointerPosition, selectPositionSecondaryDrag);
             }
         }
 
         private bool isDragging(Vector2 pointerPosition, Vector2 selectPosition)
         {
             float distance = Vector2.Distance(pointerPosition, selectPosition);
-            return distance > _dragDistanceThreshold;
+            return distance > dragDistanceThreshold;
         }
 
         private void OnHold(InputAction.CallbackContext obj)
         {
-            _isHoldingPrimaryDrag = true;
-            _selectPositionPrimaryDrag = inputProvider.PointerInput();
+            isHoldingPrimaryDrag = true;
+            selectPositionPrimaryDrag = inputProvider.PointerInput();
         }
 
         private void OnHoldRightClick(InputAction.CallbackContext obj)
         {
-            _isHoldingSecondaryDrag = true;
-            _selectPositionSecondaryDrag = inputProvider.PointerInput();
+            isHoldingSecondaryDrag = true;
+            selectPositionSecondaryDrag = inputProvider.PointerInput();
         }
 
         private void OnHoldCanceled(InputAction.CallbackContext obj)
         {
-            _isHoldingPrimaryDrag = false;
+            isHoldingPrimaryDrag = false;
             primaryDragging = false;
         }
 
         private void OnHoldRightClickCanceled(InputAction.CallbackContext obj)
         {
-            _isHoldingSecondaryDrag = false;
+            isHoldingSecondaryDrag = false;
             secondaryDragging = false;
         }
 

--- a/Tests/PlayMode/MoveDollhouseViewTest.cs
+++ b/Tests/PlayMode/MoveDollhouseViewTest.cs
@@ -244,7 +244,7 @@ namespace ReupVirtualTwinTests.behaviours
             Vector2 startFinger2 = new Vector2(400, 400);
             Vector2 endFinger1 = new Vector2(100, 100);
             Vector2 endFinger2 = new Vector2(500, 500);
-            yield return PointerUtils.TouchGesture(input, touch, startFinger1, startFinger2, endFinger1, endFinger2, 10);
+            yield return PointerUtils.AbsolutePositionTouchGesture(input, touch, startFinger1, startFinger2, endFinger1, endFinger2, 10);
 
             Assert.AreEqual(Vector3.zero, dollhouseViewWrapper.position);
             yield return null;

--- a/Tests/PlayMode/RotateDollhouseViewTest.cs
+++ b/Tests/PlayMode/RotateDollhouseViewTest.cs
@@ -24,7 +24,7 @@ namespace ReupVirtualTwinTests.behaviours
         private float initialRotationY;
         private float keyboardRotationSpeedDegreesPerSecond;
         private float timeInSecsForHoldingButton = 0.25f;
-        private float errorToleranceInDegrees = 1.0f;
+        private float errorToleranceInDegrees = 2.5f;
         private const int steps = 10;
 
         [UnitySetUp]
@@ -171,7 +171,7 @@ namespace ReupVirtualTwinTests.behaviours
             Assert.AreEqual(initialRotationY, dollhouseViewWrapper.localEulerAngles.y);
 
             float percentageOfTheScreenDragged = 5f / 100f;
-            float performedRotationInDegrees = percentageOfTheScreenDragged * 180;
+            float performedRotationInDegrees = percentageOfTheScreenDragged * rotateDhvCameraMouseBehavior.verticalRotationPerScreenHeight;
             Vector2 initialPosition = new Vector2(0.0f, 1.0f);
             Vector2 finalPosition = new Vector2(0.0f, 0.95f);
 
@@ -189,7 +189,7 @@ namespace ReupVirtualTwinTests.behaviours
             Assert.AreEqual(initialRotationY, dollhouseViewWrapper.localEulerAngles.y);
 
             float percentageOfTheScreenDragged = 5f / 100f;
-            float performedRotationInDegrees = percentageOfTheScreenDragged * 180;
+            float performedRotationInDegrees = percentageOfTheScreenDragged * rotateDhvCameraMouseBehavior.verticalRotationPerScreenHeight;
             Vector2 initialPosition = new Vector2(0.0f, 0.0f);
             Vector2 finalPosition = new Vector2(0.0f, 0.05f);
 
@@ -207,7 +207,7 @@ namespace ReupVirtualTwinTests.behaviours
             Assert.AreEqual(initialRotationY, dollhouseViewWrapper.localEulerAngles.y);
 
             float percentageOfTheScreenDragged = 5f / 100f;
-            float performedRotationInDegrees = percentageOfTheScreenDragged * 180;
+            float performedRotationInDegrees = percentageOfTheScreenDragged * rotateDhvCameraMouseBehavior.horizontalRotationPerScreenWidth;
             Vector2 initialPosition = new Vector2(0.5f, 0.5f);
             Vector2 finalPosition = new Vector2(0.45f, 0.5f);
 
@@ -225,7 +225,7 @@ namespace ReupVirtualTwinTests.behaviours
             Assert.AreEqual(initialRotationY, dollhouseViewWrapper.localEulerAngles.y);
 
             float percentageOfTheScreenDragged = 5f / 100f;
-            float performedRotationInDegrees = percentageOfTheScreenDragged * 180;
+            float performedRotationInDegrees = percentageOfTheScreenDragged * rotateDhvCameraMouseBehavior.horizontalRotationPerScreenWidth;
             Vector2 initialPosition = new Vector2(0.5f, 0.5f);
             Vector2 finalPosition = new Vector2(0.55f, 0.5f);
 
@@ -359,7 +359,7 @@ namespace ReupVirtualTwinTests.behaviours
             Assert.AreEqual(initialRotationY, dollhouseViewWrapper.localEulerAngles.y);
 
             float percentageOfTheScreenDragged = 5f / 100f;
-            float performedRotationInDegrees = percentageOfTheScreenDragged * 180;
+            float performedRotationInDegrees = percentageOfTheScreenDragged * rotateDhvCameraTouchBehavior.verticalRotationPerScreenHeight;
             Vector2 initialPositionTouch1 = new Vector2(0.0f, 1.0f);
             Vector2 initialPositionTouch2 = new Vector2(0.1f, 1.0f);
             Vector2 finalPositionTouch1 = new Vector2(0.0f, 0.95f);

--- a/Tests/PlayMode/RotateDollhouseViewTest.cs
+++ b/Tests/PlayMode/RotateDollhouseViewTest.cs
@@ -1,6 +1,8 @@
 using System.Collections;
 using NUnit.Framework;
 using ReupVirtualTwin.behaviours;
+using ReupVirtualTwin.enums;
+using ReupVirtualTwin.helpers;
 using ReupVirtualTwinTests.utils;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -53,13 +55,6 @@ namespace ReupVirtualTwinTests.behaviours
             yield return null;
         }
 
-        private float NormalizeAngle(float angle)
-        {
-            angle = angle % 360;
-            if (angle < 0) angle += 360;
-            return angle;
-        }
-
         [UnityTest]
         public IEnumerator UpArrowKeyShouldRotateDHVUp()
         {
@@ -71,7 +66,7 @@ namespace ReupVirtualTwinTests.behaviours
             input.Release(keyboard.upArrowKey);
             yield return null;
 
-            float expectedRotation = NormalizeAngle(initialRotationX + (keyboardRotationSpeedDegreesPerSecond * timeInSecsForHoldingButton));
+            float expectedRotation = MathUtils.NormalizeTo360Degrees(initialRotationX + (keyboardRotationSpeedDegreesPerSecond * timeInSecsForHoldingButton));
             Assert.AreEqual(expectedRotation, dollhouseViewWrapper.localEulerAngles.x, errorToleranceInDegrees);
         }
 
@@ -86,7 +81,7 @@ namespace ReupVirtualTwinTests.behaviours
             input.Release(keyboard.downArrowKey);
             yield return null;
 
-            float expectedRotation = NormalizeAngle(initialRotationX - (keyboardRotationSpeedDegreesPerSecond * timeInSecsForHoldingButton));
+            float expectedRotation = MathUtils.NormalizeTo360Degrees(initialRotationX - (keyboardRotationSpeedDegreesPerSecond * timeInSecsForHoldingButton));
             Assert.AreEqual(expectedRotation, dollhouseViewWrapper.localEulerAngles.x, errorToleranceInDegrees);
         }
 
@@ -101,7 +96,7 @@ namespace ReupVirtualTwinTests.behaviours
             input.Release(keyboard.leftArrowKey);
             yield return null;
 
-            float expectedRotation = NormalizeAngle(initialRotationY + (keyboardRotationSpeedDegreesPerSecond * timeInSecsForHoldingButton));
+            float expectedRotation = MathUtils.NormalizeTo360Degrees(initialRotationY + (keyboardRotationSpeedDegreesPerSecond * timeInSecsForHoldingButton));
             Assert.AreEqual(expectedRotation, dollhouseViewWrapper.localEulerAngles.y, errorToleranceInDegrees);
         }
 
@@ -116,7 +111,7 @@ namespace ReupVirtualTwinTests.behaviours
             input.Release(keyboard.rightArrowKey);
             yield return null;
 
-            float expectedRotation = NormalizeAngle(initialRotationY - (keyboardRotationSpeedDegreesPerSecond * timeInSecsForHoldingButton));
+            float expectedRotation = MathUtils.NormalizeTo360Degrees(initialRotationY - (keyboardRotationSpeedDegreesPerSecond * timeInSecsForHoldingButton));
             Assert.AreEqual(expectedRotation, dollhouseViewWrapper.localEulerAngles.y, errorToleranceInDegrees);
         }
 
@@ -126,14 +121,14 @@ namespace ReupVirtualTwinTests.behaviours
             Assert.AreEqual(initialRotationX, dollhouseViewWrapper.localEulerAngles.x);
             Assert.AreEqual(initialRotationY, dollhouseViewWrapper.localEulerAngles.y);
 
-            float angleToClamp = rotateDhvCameraKeyboardBehavior.maxVerticalAngle + 5;
+            float angleToClamp = RomuloGlobalSettings.maxVerticalAngle + 5;
             float timeToHoldHeyBeyondClamp = Mathf.Abs((angleToClamp - initialRotationX)) / keyboardRotationSpeedDegreesPerSecond;
 
             input.Press(keyboard.upArrowKey);
             yield return new WaitForSeconds(timeToHoldHeyBeyondClamp);
             input.Release(keyboard.upArrowKey);
 
-            Assert.AreEqual(rotateDhvCameraKeyboardBehavior.maxVerticalAngle, dollhouseViewWrapper.localEulerAngles.x, errorToleranceInDegrees);
+            Assert.AreEqual(RomuloGlobalSettings.maxVerticalAngle, dollhouseViewWrapper.localEulerAngles.x, errorToleranceInDegrees);
         }
 
         [UnityTest]
@@ -142,14 +137,14 @@ namespace ReupVirtualTwinTests.behaviours
             Assert.AreEqual(initialRotationX, dollhouseViewWrapper.localEulerAngles.x);
             Assert.AreEqual(initialRotationY, dollhouseViewWrapper.localEulerAngles.y);
 
-            float angleToClamp = rotateDhvCameraKeyboardBehavior.minVerticalAngle - 5;
+            float angleToClamp = RomuloGlobalSettings.minVerticalAngle - 5;
             float timeToHoldHeyBeyondClamp = Mathf.Abs((angleToClamp - initialRotationX)) / keyboardRotationSpeedDegreesPerSecond;
 
             input.Press(keyboard.downArrowKey);
             yield return new WaitForSeconds(timeToHoldHeyBeyondClamp);
             input.Release(keyboard.downArrowKey);
 
-            Assert.AreEqual(rotateDhvCameraKeyboardBehavior.minVerticalAngle, dollhouseViewWrapper.localEulerAngles.x, errorToleranceInDegrees);
+            Assert.AreEqual(RomuloGlobalSettings.minVerticalAngle, dollhouseViewWrapper.localEulerAngles.x, errorToleranceInDegrees);
         }
 
         [UnityTest]
@@ -171,7 +166,7 @@ namespace ReupVirtualTwinTests.behaviours
             Assert.AreEqual(initialRotationY, dollhouseViewWrapper.localEulerAngles.y);
 
             float percentageOfTheScreenDragged = 5f / 100f;
-            float performedRotationInDegrees = percentageOfTheScreenDragged * rotateDhvCameraMouseBehavior.verticalRotationPerScreenHeight;
+            float performedRotationInDegrees = percentageOfTheScreenDragged * RomuloGlobalSettings.verticalRotationPerScreenHeight;
             Vector2 initialPosition = new Vector2(0.0f, 1.0f);
             Vector2 finalPosition = new Vector2(0.0f, 0.95f);
 
@@ -189,7 +184,7 @@ namespace ReupVirtualTwinTests.behaviours
             Assert.AreEqual(initialRotationY, dollhouseViewWrapper.localEulerAngles.y);
 
             float percentageOfTheScreenDragged = 5f / 100f;
-            float performedRotationInDegrees = percentageOfTheScreenDragged * rotateDhvCameraMouseBehavior.verticalRotationPerScreenHeight;
+            float performedRotationInDegrees = percentageOfTheScreenDragged * RomuloGlobalSettings.verticalRotationPerScreenHeight;
             Vector2 initialPosition = new Vector2(0.0f, 0.0f);
             Vector2 finalPosition = new Vector2(0.0f, 0.05f);
 
@@ -207,7 +202,7 @@ namespace ReupVirtualTwinTests.behaviours
             Assert.AreEqual(initialRotationY, dollhouseViewWrapper.localEulerAngles.y);
 
             float percentageOfTheScreenDragged = 5f / 100f;
-            float performedRotationInDegrees = percentageOfTheScreenDragged * rotateDhvCameraMouseBehavior.horizontalRotationPerScreenWidth;
+            float performedRotationInDegrees = percentageOfTheScreenDragged * RomuloGlobalSettings.horizontalRotationPerScreenWidth;
             Vector2 initialPosition = new Vector2(0.5f, 0.5f);
             Vector2 finalPosition = new Vector2(0.45f, 0.5f);
 
@@ -225,7 +220,7 @@ namespace ReupVirtualTwinTests.behaviours
             Assert.AreEqual(initialRotationY, dollhouseViewWrapper.localEulerAngles.y);
 
             float percentageOfTheScreenDragged = 5f / 100f;
-            float performedRotationInDegrees = percentageOfTheScreenDragged * rotateDhvCameraMouseBehavior.horizontalRotationPerScreenWidth;
+            float performedRotationInDegrees = percentageOfTheScreenDragged * RomuloGlobalSettings.horizontalRotationPerScreenWidth;
             Vector2 initialPosition = new Vector2(0.5f, 0.5f);
             Vector2 finalPosition = new Vector2(0.55f, 0.5f);
 
@@ -244,7 +239,7 @@ namespace ReupVirtualTwinTests.behaviours
 
             yield return PointerUtils.DragMouseRightButton(input, mouse, new Vector2(0.5f, 0.5f), new Vector2(0.5f, -100.0f), steps);
 
-            Assert.AreEqual(rotateDhvCameraMouseBehavior.maxVerticalAngle, dollhouseViewWrapper.localEulerAngles.x, errorToleranceInDegrees);
+            Assert.AreEqual(RomuloGlobalSettings.maxVerticalAngle, dollhouseViewWrapper.localEulerAngles.x, errorToleranceInDegrees);
         }
 
         [UnityTest]
@@ -255,7 +250,7 @@ namespace ReupVirtualTwinTests.behaviours
 
             yield return PointerUtils.DragMouseRightButton(input, mouse, new Vector2(0.5f, 0.5f), new Vector2(0.5f, 100.0f), steps);
 
-            Assert.AreEqual(rotateDhvCameraMouseBehavior.minVerticalAngle, dollhouseViewWrapper.localEulerAngles.x, errorToleranceInDegrees);
+            Assert.AreEqual(RomuloGlobalSettings.minVerticalAngle, dollhouseViewWrapper.localEulerAngles.x, errorToleranceInDegrees);
         }
 
         [UnityTest]
@@ -359,7 +354,7 @@ namespace ReupVirtualTwinTests.behaviours
             Assert.AreEqual(initialRotationY, dollhouseViewWrapper.localEulerAngles.y);
 
             float percentageOfTheScreenDragged = 5f / 100f;
-            float performedRotationInDegrees = percentageOfTheScreenDragged * rotateDhvCameraTouchBehavior.verticalRotationPerScreenHeight;
+            float performedRotationInDegrees = percentageOfTheScreenDragged * RomuloGlobalSettings.verticalRotationPerScreenHeight;
             Vector2 initialPositionTouch1 = new Vector2(0.0f, 1.0f);
             Vector2 initialPositionTouch2 = new Vector2(0.1f, 1.0f);
             Vector2 finalPositionTouch1 = new Vector2(0.0f, 0.95f);
@@ -385,7 +380,7 @@ namespace ReupVirtualTwinTests.behaviours
 
             yield return PointerUtils.TouchGesture(input, touch, initialPositionTouch1, initialPositionTouch2, finalPositionTouch1, finalPositionTouch2, steps);
 
-            Assert.AreEqual(rotateDhvCameraTouchBehavior.maxVerticalAngle, dollhouseViewWrapper.localEulerAngles.x, errorToleranceInDegrees);
+            Assert.AreEqual(RomuloGlobalSettings.maxVerticalAngle, dollhouseViewWrapper.localEulerAngles.x, errorToleranceInDegrees);
         }
 
         [UnityTest]
@@ -401,7 +396,7 @@ namespace ReupVirtualTwinTests.behaviours
 
             yield return PointerUtils.TouchGesture(input, touch, initialPositionTouch1, initialPositionTouch2, finalPositionTouch1, finalPositionTouch2, steps);
 
-            Assert.AreEqual(rotateDhvCameraTouchBehavior.minVerticalAngle, dollhouseViewWrapper.localEulerAngles.x, errorToleranceInDegrees);
+            Assert.AreEqual(RomuloGlobalSettings.minVerticalAngle, dollhouseViewWrapper.localEulerAngles.x, errorToleranceInDegrees);
         }
     }
 }

--- a/Tests/PlayMode/ZoomDhvCameraTest.cs
+++ b/Tests/PlayMode/ZoomDhvCameraTest.cs
@@ -99,7 +99,7 @@ namespace ReupVirtualTwinTests.behaviours
             Vector2 ZoomInEndFinger2 = new Vector2(500, 500);
 
             float expectedZoomInFov = calculateNextPinchZoomFov(ZoomInStartFinger1, ZoomInStartFinger2, ZoomInEndFinger1, ZoomInEndFinger2);
-            yield return PointerUtils.TouchGesture(input, touch, ZoomInStartFinger1, ZoomInStartFinger2, ZoomInEndFinger1, ZoomInEndFinger2, zoomSepts);
+            yield return PointerUtils.AbsolutePositionTouchGesture(input, touch, ZoomInStartFinger1, ZoomInStartFinger2, ZoomInEndFinger1, ZoomInEndFinger2, zoomSepts);
             yield return new WaitForSeconds(0.5f);
             Assert.AreEqual(expectedZoomInFov, dhvCineMachineComponent.Lens.FieldOfView, errorToleranceInDegrees);
 
@@ -109,7 +109,7 @@ namespace ReupVirtualTwinTests.behaviours
             Vector2 ZoomOutEndFinger2 = new Vector2(400, 400);
 
             float expectedZoomOutFov = calculateNextPinchZoomFov(ZoomOutStartFinger1, ZoomOutStartFinger2, ZoomOutEndFinger1, ZoomOutEndFinger2);
-            yield return PointerUtils.TouchGesture(input, touch, ZoomOutStartFinger1, ZoomOutStartFinger2, ZoomOutEndFinger1, ZoomOutEndFinger2, zoomSepts);
+            yield return PointerUtils.AbsolutePositionTouchGesture(input, touch, ZoomOutStartFinger1, ZoomOutStartFinger2, ZoomOutEndFinger1, ZoomOutEndFinger2, zoomSepts);
             yield return new WaitForSeconds(0.5f);
             Assert.AreEqual(expectedZoomOutFov, dhvCineMachineComponent.Lens.FieldOfView, errorToleranceInDegrees);
 

--- a/Tests/TestUtils/PointerUtils.cs
+++ b/Tests/TestUtils/PointerUtils.cs
@@ -110,7 +110,7 @@ namespace ReupVirtualTwinTests.utils
             yield return null;
         }
 
-        public static IEnumerator TouchGesture(
+        public static IEnumerator AbsolutePositionTouchGesture(
             InputTestFixture input,
             Touchscreen touch,
             Vector2 startFinger1Position,
@@ -142,6 +142,25 @@ namespace ReupVirtualTwinTests.utils
             input.EndTouch(0, endFinger1Position, Vector2.zero, true, touch);
             input.EndTouch(1, endFinger2Position, Vector2.zero, true, touch);
             yield return null;
+        }
+
+        public static IEnumerator TouchGesture(
+            InputTestFixture input,
+            Touchscreen touch,
+            Vector2 relativeStartFinger1Position,
+            Vector2 relativeStartFinger2Position,
+            Vector2 relativeEndFinger1Position,
+            Vector2 relativeEndFinger2Position,
+            int steps)
+        {
+            yield return AbsolutePositionTouchGesture(
+                input,
+                touch,
+                Camera.main.ViewportToScreenPoint(relativeStartFinger1Position),
+                Camera.main.ViewportToScreenPoint(relativeStartFinger2Position),
+                Camera.main.ViewportToScreenPoint(relativeEndFinger1Position),
+                Camera.main.ViewportToScreenPoint(relativeEndFinger2Position),
+                steps);
         }
 
         public static void Tap(InputTestFixture input, Touchscreen touch, Vector2 tapPosition, int touchId = 0){

--- a/Tests/TestUtils/ReupSceneInstantiator.cs
+++ b/Tests/TestUtils/ReupSceneInstantiator.cs
@@ -49,6 +49,7 @@ namespace ReupVirtualTwinTests.utils
             public ICharacterPositionManager characterPositionManager;
             public RotateDhvCameraKeyboard rotateDhvCameraKeyboardBehavior;
             public RotateDhvCameraMouse rotateDhvCameraMouseBehavior;
+            public RotateDhvCameraTouch rotateDhvCameraTouchBehavior;
         }
         public static SceneObjects InstantiateSceneWithBuildingFromPrefab(GameObject buildingPrefab, Action<GameObject> modifyBuilding)
         {
@@ -128,6 +129,8 @@ namespace ReupVirtualTwinTests.utils
 
             RotateDhvCameraMouse rotateDhvCameraMouseBehavior = dollhouseViewWrapper.GetComponent<RotateDhvCameraMouse>();
 
+            RotateDhvCameraTouch rotateDhvCameraTouchBehavior = dollhouseViewWrapper.GetComponent<RotateDhvCameraTouch>();
+
             ModelInfoManager modelInfoManager = baseGlobalScriptGameObject.transform.Find("ModelInfo").GetComponent<ModelInfoManager>();
 
             ObjectRegistry objectRegistry = baseGlobalScriptGameObject.transform.Find("ObjectRegistry").GetComponent<ObjectRegistry>();
@@ -179,7 +182,8 @@ namespace ReupVirtualTwinTests.utils
                 houseContainer = houseContainer,
                 characterPositionManager = characterPositionManager,
                 rotateDhvCameraKeyboardBehavior = rotateDhvCameraKeyboardBehavior,
-                rotateDhvCameraMouseBehavior = rotateDhvCameraMouseBehavior
+                rotateDhvCameraMouseBehavior = rotateDhvCameraMouseBehavior,
+                rotateDhvCameraTouchBehavior = rotateDhvCameraTouchBehavior,
             };
         }
 


### PR DESCRIPTION
[Reup-409](https://macheight-reup.atlassian.net/browse/REUP-409)

As a user, I want to rotate the camera in DHV mode to view the house from various angles.

AC:

In DHV mode, the user can rotate the camera view using one of the following methods:

Two-finger rotation on touch screens to rotate horizontally, the angle traveled by the line that connects the 2 touch positions, is the angle applied to the camera rotation by a factor.

Two-finger vertical drag to rotate vertically

The rotation should occur around a fixed point in front of the camera, not around the camera itself.

The camera’s attack angle relative to the horizontal plane should not be negative, with positive angles indicating the camera is looking downward.

The camera’s attack angle should not exceed 90 degrees.