### PR TITLE
Reup492 rotate with both mouse buttons

### DIFF
--- a/Runtime/Behaviours/MoveDhvCamera.cs
+++ b/Runtime/Behaviours/MoveDhvCamera.cs
@@ -89,7 +89,7 @@ namespace ReupVirtualTwin.behaviours
                 UpdateOriginalPositions();
                 return;
             }
-            if (!dragManager.primaryDragging)
+            if (!dragManager.primaryDragging || dragManager.secondaryDragging)
             {
                 return;
             }

--- a/Runtime/Behaviours/MoveDhvCamera.cs
+++ b/Runtime/Behaviours/MoveDhvCamera.cs
@@ -84,12 +84,12 @@ namespace ReupVirtualTwin.behaviours
 
         void PointerUpdatePosition()
         {
-            if (gesturesManager.gestureInProgress)
+            if (gesturesManager.gestureInProgress || dragManager.secondaryDragging)
             {
                 UpdateOriginalPositions();
                 return;
             }
-            if (!dragManager.primaryDragging || dragManager.secondaryDragging)
+            if (!dragManager.primaryDragging)
             {
                 return;
             }

--- a/Runtime/Helpers/YieldUtils.cs
+++ b/Runtime/Helpers/YieldUtils.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System;
+
+namespace ReupVirtualTwin.helpers{
+    public static class YieldUtils{
+
+        public static Func<T, IEnumerator> YieldifyAction<T>(Action<T> action)
+        {
+            return (T input) => Yieldify(action, input);
+        }
+
+        public static Func<T, U, IEnumerator> YieldifyAction<T, U>(Action<T, U> action)
+        {
+            return (T input0, U input1) => Yieldify(action, input0, input1);
+        }
+
+        public static IEnumerator Yieldify<T>(Action<T> action, T input)
+        {
+            action(input);
+            yield return null;
+        }
+        public static IEnumerator Yieldify<T, U>(Action<T, U> action, T input0, U input1)
+        {
+            action(input0, input1);
+            yield return null;
+        }
+    }
+
+}

--- a/Runtime/Helpers/YieldUtils.cs.meta
+++ b/Runtime/Helpers/YieldUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fb2bd351ae1fdcc42b5d2abe877f3e14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/RotateDollhouseViewTest.cs
+++ b/Tests/PlayMode/RotateDollhouseViewTest.cs
@@ -398,5 +398,26 @@ namespace ReupVirtualTwinTests.behaviours
 
             Assert.AreEqual(RomuloGlobalSettings.minVerticalAngle, dollhouseViewWrapper.localEulerAngles.x, errorToleranceInDegrees);
         }
+
+        [UnityTest]
+        public IEnumerator ShouldOnlyRotateIfBothMouseButtonsAreHold()
+        {
+            Assert.AreEqual(initialRotationX, dollhouseViewWrapper.localEulerAngles.x);
+            Assert.AreEqual(initialRotationY, dollhouseViewWrapper.localEulerAngles.y);
+            Assert.AreEqual(Vector3.zero, dollhouseViewWrapper.position);
+
+            float percentageOfTheScreenDragged = 5f / 100f;
+            float performedRotationInDegrees = percentageOfTheScreenDragged * RomuloGlobalSettings.horizontalRotationPerScreenWidth;
+            Vector2 initialPosition = new Vector2(0.5f, 0.5f);
+            Vector2 finalPosition = new Vector2(0.55f, 0.5f);
+
+            yield return PointerUtils.DragMouseBothButtons(input, mouse, initialPosition, finalPosition, steps);
+
+            float expectedRotation = initialRotationY + performedRotationInDegrees;
+
+            Assert.AreEqual(expectedRotation, dollhouseViewWrapper.localEulerAngles.y, errorToleranceInDegrees);
+            Assert.AreEqual(Vector3.zero, dollhouseViewWrapper.position);
+        }
+
     }
 }

--- a/Tests/TestUtils/PointerUtils.cs
+++ b/Tests/TestUtils/PointerUtils.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using System;
 using UnityEngine.InputSystem;
 using InSys = UnityEngine.InputSystem;
+using ReupVirtualTwin.helpers;
 
 namespace ReupVirtualTwinTests.utils
 {
@@ -19,12 +20,12 @@ namespace ReupVirtualTwinTests.utils
                 startMousePoint,
                 endMousePoint,
                 steps,
-                (Vector2 startPosition) => input.Move(mouse.position, startPosition),
+                YieldUtils.YieldifyAction((Vector2 startPosition) => input.Move(mouse.position, startPosition)),
                 (Vector2 currentPosition, Vector2 delta) => {
                     input.Move(mouse.position, currentPosition, delta);
                     input.Set(mouse.delta, delta);
                 },
-                (Vector2 endPosition) => { }
+                YieldUtils.YieldifyAction((Vector2 endPosition) => { })
             );
         }
         public static IEnumerator DragMouseLeftButton(
@@ -38,12 +39,37 @@ namespace ReupVirtualTwinTests.utils
                 startMousePoint,
                 endMousePoint,
                 steps,
-                (Vector2 startPosition) => { input.Move(mouse.position, startPosition); input.Press(mouse.leftButton); },
+                YieldUtils.YieldifyAction((Vector2 startPosition) => { input.Move(mouse.position, startPosition); input.Press(mouse.leftButton); }),
                 (Vector2 currentPosition, Vector2 delta) => {
                     input.Move(mouse.position, currentPosition, delta);
                     input.Set(mouse.delta, delta);
                 },
-                (Vector2 endPosition) => input.Release(mouse.leftButton)
+                YieldUtils.YieldifyAction((Vector2 endPosition) => input.Release(mouse.leftButton))
+            );
+        }
+
+
+        public static IEnumerator DragMouseBothButtons(
+            InputTestFixture input,
+            Mouse mouse,
+            Vector2 startMousePoint,
+            Vector2 endMousePoint,
+            int steps
+        ) {
+            yield return MovePointer(
+                startMousePoint,
+                endMousePoint,
+                steps,
+                CreatePressBothMouseButtonsAtPositionDelegate(input, mouse),
+                (Vector2 currentPosition, Vector2 delta) => {
+                    input.Move(mouse.position, currentPosition, delta);
+                    input.Set(mouse.delta, delta);
+                },
+                YieldUtils.YieldifyAction((Vector2 endPosition) =>
+                {
+                    input.Release(mouse.leftButton);
+                    input.Release(mouse.rightButton);
+                })
             );
         }
 
@@ -58,12 +84,12 @@ namespace ReupVirtualTwinTests.utils
                 startMousePoint,
                 endMousePoint,
                 steps,
-                (Vector2 startPosition) => { input.Move(mouse.position, startPosition); input.Press(mouse.rightButton); },
+                YieldUtils.YieldifyAction((Vector2 startPosition) => { input.Move(mouse.position, startPosition); input.Press(mouse.rightButton); }),
                 (Vector2 currentPosition, Vector2 delta) => {
                     input.Move(mouse.position, currentPosition, delta);
                     input.Set(mouse.delta, delta);
                 },
-                (Vector2 endPosition) => input.Release(mouse.leftButton)
+                YieldUtils.YieldifyAction((Vector2 endPosition) => input.Release(mouse.leftButton))
             );
         }
 
@@ -79,9 +105,9 @@ namespace ReupVirtualTwinTests.utils
                 startScreenPosition,
                 endScreenPosition,
                 steps,
-                (Vector2 startPosition) => input.SetTouch(touchId, InSys.TouchPhase.Began, startPosition, Vector2.zero, true, touch),
+                YieldUtils.YieldifyAction((Vector2 startPosition) => input.SetTouch(touchId, InSys.TouchPhase.Began, startPosition, Vector2.zero, true, touch)),
                 (Vector2 currentPosition, Vector2 delta) => input.SetTouch(touchId, InSys.TouchPhase.Moved, currentPosition, delta, true, touch),
-                (Vector2 endPosition) => input.EndTouch(touchId, endPosition, Vector2.zero, true, touch)
+                YieldUtils.YieldifyAction((Vector2 endPosition) => input.EndTouch(touchId, endPosition, Vector2.zero, true, touch))
             );
         }
 
@@ -89,13 +115,13 @@ namespace ReupVirtualTwinTests.utils
             Vector2 startScreenPosition,
             Vector2 endScreenPosition,
             int steps,
-            Action<Vector2> startAction,
+            Func<Vector2, IEnumerator> startAction,
             Action<Vector2, Vector2> stepAction,
-            Action<Vector2> endAction
+            Func<Vector2, IEnumerator> endAction
         ) {
             Vector2 startPosition = Camera.main.ViewportToScreenPoint(startScreenPosition);
             Vector2 endPosition = Camera.main.ViewportToScreenPoint(endScreenPosition);
-            startAction(startPosition);
+            yield return startAction(startPosition);
             for (int i = 1; i < steps + 1; i++)
             {
                 float prevT = (float)(i-1) / steps;
@@ -106,8 +132,7 @@ namespace ReupVirtualTwinTests.utils
                 stepAction(currentPosition, delta);
                 yield return null;
             }
-            endAction(endPosition);
-            yield return null;
+            yield return endAction(endPosition);
         }
 
         public static IEnumerator AbsolutePositionTouchGesture(
@@ -168,5 +193,18 @@ namespace ReupVirtualTwinTests.utils
             input.SetTouch(touchId, phase, tapPosition, 1.0f, Vector2.zero, true, touch);
             input.EndTouch(touchId, tapPosition);
         }
+
+        static Func<Vector2, IEnumerator> CreatePressBothMouseButtonsAtPositionDelegate(InputTestFixture input, Mouse mouse){
+            IEnumerator P(Vector2 startPosition, InputTestFixture input, Mouse mouse){
+                input.Move(mouse.position, startPosition);
+                yield return null;
+                input.Press(mouse.leftButton);
+                yield return null;
+                input.Press(mouse.rightButton);
+                yield return null;
+            }
+            return (Vector2 startPosition) => P(startPosition, input, mouse);
+        }
+
     }
 }


### PR DESCRIPTION
[Reup492](https://macheight-reup.atlassian.net/browse/REUP-492?atlOrigin=eyJpIjoiMzk3MTcyNmY5MjA0NDk0NjhkNzY0MmJlM2UwMDhkMGQiLCJwIjoiaiJ9)

As a user, I want to only rotate when I’m holding down both mouse buttons at the same time, so I don’t get a weird mix of rotation and pan behavior.

AC:

When user hold down both mouse buttons, only rotation movement is enabled in dhv

