### PR TITLE
Reup-498 Automate tagging process in Unity

### DIFF
--- a/Editor/EditorUtils/TagsApplierUtil.cs
+++ b/Editor/EditorUtils/TagsApplierUtil.cs
@@ -1,0 +1,81 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using ReupVirtualTwin.dataModels;
+using ReupVirtualTwin.webRequestersInterfaces;
+using System.Threading.Tasks;
+using UnityEngine;
+using ReupVirtualTwin.models;
+using System;
+
+namespace ReupVirtualTwin.editor
+{
+    public class TagsApplierUtil
+    {
+        private const int PAGE = 1;
+        private const int PAGE_SIZE = 10000;
+        private static readonly Regex TagRegex = new Regex(@"TAG_(\d+)", RegexOptions.Compiled);
+        public static async Task<List<string>> ApplyTags(GameObject building, ITagsApiConsumer tagsApiConsumer)
+        {
+            List<string> errorMessages = new List<string>();
+            try
+            {
+                Tag[] apiTags = await fetchTags(tagsApiConsumer);
+                Dictionary<string, Tag> apiTagsDict = apiTags.ToDictionary(tag => tag.id);
+                ApplyTagsToTree(building, apiTagsDict, errorMessages);
+            }
+            catch (Exception e)
+            {
+                errorMessages.Add(e.Message);
+            }
+            return errorMessages;
+        }
+
+        private static async Task<Tag[]> fetchTags(ITagsApiConsumer tagsApiConsumer)
+        {
+            PaginationResult<Tag> fetchedTagsResult = await tagsApiConsumer.GetTags(PAGE, PAGE_SIZE);
+            return fetchedTagsResult.results;
+        }
+
+        private static void ApplyTagsToTree(GameObject obj, Dictionary<string, Tag> apiTags, List<string> errorMessages)
+        {
+            ApplyTagsToObject(obj, apiTags, errorMessages);
+
+            foreach (Transform child in obj.transform)
+            {
+                ApplyTagsToTree(child.gameObject, apiTags, errorMessages);
+            }
+        }
+
+        private static void ApplyTagsToObject(GameObject obj, Dictionary<string, Tag> apiTags, List<string> errorMessages)
+        {
+            List<string> objectTagsIds = ExtractTagsIdsFromObject(obj);            
+            List<Tag> tagsToApply = objectTagsIds
+                .Where(id => apiTags.TryGetValue(id, out _))
+                .Select(id => apiTags[id])
+                .ToList();
+
+            List<string> notFoundTagsIds = objectTagsIds.Where(id => tagsToApply.All(tag => tag.id != id)).ToList();
+            if (notFoundTagsIds.Count > 0)
+            {
+                string notFoundTagIdsStr = string.Join(" - ", notFoundTagsIds);
+                errorMessages.Add($"Tags Ids not found in '{obj.name}': {notFoundTagIdsStr}");
+            }
+
+            ObjectTags objectTags = obj.GetComponent<ObjectTags>() ?? obj.gameObject.AddComponent<ObjectTags>();
+            Dictionary<string, Tag> existingTagsDict = objectTags.GetTags().ToDictionary(tag => tag.id);
+            List<Tag> tagsToAdd = tagsToApply.Where(tag => !existingTagsDict.ContainsKey(tag.id)).ToList();
+
+            objectTags.AddTags(tagsToAdd.ToArray());
+        }
+
+        private static List<string> ExtractTagsIdsFromObject(GameObject gameObject)
+        {   
+            return TagRegex.Matches(gameObject.name)
+                          .Cast<Match>()
+                          .Where(match => match.Success)
+                          .Select(match => match.Groups[1].Value)
+                          .ToList();
+        }
+    }
+}

--- a/Editor/EditorUtils/TagsApplierUtil.cs
+++ b/Editor/EditorUtils/TagsApplierUtil.cs
@@ -12,9 +12,6 @@ namespace ReupVirtualTwin.editor
 {
     public class TagsApplierUtil
     {
-        private const int PAGE = 1;
-        private const int PAGE_SIZE = 10000;
-        private static readonly Regex TagRegex = new Regex(@"TAG_(\d+)", RegexOptions.Compiled);
         public static async Task<List<string>> ApplyTags(GameObject building, ITagsApiConsumer tagsApiConsumer)
         {
             List<string> errorMessages = new List<string>();
@@ -33,7 +30,10 @@ namespace ReupVirtualTwin.editor
 
         private static async Task<Tag[]> fetchTags(ITagsApiConsumer tagsApiConsumer)
         {
-            PaginationResult<Tag> fetchedTagsResult = await tagsApiConsumer.GetTags(PAGE, PAGE_SIZE);
+            int page = 1;
+            int pageSize = 10000;
+
+            PaginationResult<Tag> fetchedTagsResult = await tagsApiConsumer.GetTags(page, pageSize);
             return fetchedTagsResult.results;
         }
 
@@ -71,7 +71,8 @@ namespace ReupVirtualTwin.editor
 
         private static List<string> ExtractTagsIdsFromObject(GameObject gameObject)
         {   
-            return TagRegex.Matches(gameObject.name)
+            var tagRegex = new Regex(@"TAG_(\d+)", RegexOptions.Compiled);
+            return tagRegex.Matches(gameObject.name)
                           .Cast<Match>()
                           .Where(match => match.Success)
                           .Select(match => match.Groups[1].Value)

--- a/Editor/EditorUtils/TagsApplierUtil.cs.meta
+++ b/Editor/EditorUtils/TagsApplierUtil.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 81a0ea412161f684a8a36b9ff04aa0fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/ExternalInstallerEditor.cs
+++ b/Editor/ExternalInstallerEditor.cs
@@ -3,6 +3,9 @@ using UnityEditor;
 using ReupVirtualTwin.controllers;
 using ReupVirtualTwin.controllerInterfaces;
 using ReupVirtualTwin.dependencyInjectors;
+using ReupVirtualTwin.webRequestersInterfaces;
+using ReupVirtualTwin.webRequesters;
+using System.Collections.Generic;
 
 namespace ReupVirtualTwin.editor
 {
@@ -14,6 +17,7 @@ namespace ReupVirtualTwin.editor
         IIdAssignerController idAssignerController = new IdController();
         ITagSystemController tagSystemController = new TagSystemController();
         IObjectInfoController objectInfoController = new ObjectInfoController();
+        ITagsApiConsumer tagsApiConsumer = new TagsApiConsumer();
         public override void OnInspectorGUI()
         {
             base.OnInspectorGUI();
@@ -47,6 +51,10 @@ namespace ReupVirtualTwin.editor
                     AddTagSystemToBuildingObjects(externalInstaller.building);
                     Debug.Log("tags script added to tree");
                 }
+                if (GUILayout.Button("Apply SketchUp tags to objects"))
+                {
+                    ApplyTagsToBuildingObjects(externalInstaller.building, tagsApiConsumer);
+                }
             }
         }
 
@@ -68,6 +76,19 @@ namespace ReupVirtualTwin.editor
         public void AddTagSystemToBuildingObjects(GameObject building)
         {
             tagSystemController.AssignTagSystemToTree(building);
+        }
+
+        public async void ApplyTagsToBuildingObjects(GameObject building, ITagsApiConsumer tagsApiConsumer)
+        {
+            List<string> errorMessages = await TagsApplierUtil.ApplyTags(building, tagsApiConsumer);
+            if (errorMessages.Count > 0)
+            {
+                EditorUtility.DisplayDialog(
+                    "Something went wrong while applying tags",
+                    string.Join("\n", errorMessages),
+                    "OK"
+                );
+            }
         }
     }
 }

--- a/Runtime/WebRequesters/TagsApiConsumer.cs
+++ b/Runtime/WebRequesters/TagsApiConsumer.cs
@@ -21,6 +21,11 @@ namespace ReupVirtualTwin.webRequesters
             return FetchTags($"page={page}");
         }
 
+        public Task<PaginationResult<Tag>> GetTags(int page, int pageSize)
+        {
+            return FetchTags($"page={page}&page_size={pageSize}");
+        }
+
         private async Task<PaginationResult<Tag>> FetchTags(string queryParams="")
         {
             string url = $"{baseUrl}tags/?{queryParams}";

--- a/Runtime/WebRequestersInterfaces/ITagsApiConsumer.cs
+++ b/Runtime/WebRequestersInterfaces/ITagsApiConsumer.cs
@@ -7,5 +7,6 @@ namespace ReupVirtualTwin.webRequestersInterfaces
     {
         public Task<PaginationResult<Tag>> GetTags();
         public Task<PaginationResult<Tag>> GetTags(int page);
+        public Task<PaginationResult<Tag>> GetTags(int page, int pageSize);
     }
 }

--- a/Tests/EditorMode/TagsApplierUtilsTest.cs
+++ b/Tests/EditorMode/TagsApplierUtilsTest.cs
@@ -181,6 +181,21 @@ namespace ReupVirtualTwinTests.editor
         }
 
         [Test]
+        public async Task ShouldNotDuplicateExistingTagsOnObject()
+        {
+            AddChildrenWithTags(building, 1);
+            GameObject child = building.transform.GetChild(0).gameObject;
+            child.AddComponent<ObjectTags>().AddTag(mockApiTags[0]);
+
+            List<string> result = await TagsApplierUtil.ApplyTags(building, mockTagsApiConsumer);
+
+            ObjectTags objectTagsChild = child.GetComponent<ObjectTags>();
+            Assert.AreEqual(1, objectTagsChild.GetTags().Count);
+            Assert.AreEqual(mockApiTags[0].id, objectTagsChild.GetTags()[0].id);
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [Test]
         public async Task ShouldReturnErrorMessagesIfTagsAreNotFound()
         {
             AddChildrenWithTags(building, 1);

--- a/Tests/EditorMode/TagsApplierUtilsTest.cs
+++ b/Tests/EditorMode/TagsApplierUtilsTest.cs
@@ -185,13 +185,29 @@ namespace ReupVirtualTwinTests.editor
         {
             AddChildrenWithTags(building, 1);
             GameObject child = building.transform.GetChild(0).gameObject;
-            child.AddComponent<ObjectTags>().AddTag(mockApiTags[0]);
+            child.GetComponent<ObjectTags>().AddTag(mockApiTags[0]);
 
             List<string> result = await TagsApplierUtil.ApplyTags(building, mockTagsApiConsumer);
 
             ObjectTags objectTagsChild = child.GetComponent<ObjectTags>();
             Assert.AreEqual(1, objectTagsChild.GetTags().Count);
             Assert.AreEqual(mockApiTags[0].id, objectTagsChild.GetTags()[0].id);
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [Test]
+        public async Task ShouldKeepPreviousAppliedTags()
+        {
+            AddChildrenWithTags(building, 1);
+            GameObject child = building.transform.GetChild(0).gameObject;
+            child.GetComponent<ObjectTags>().AddTag(mockApiTags[1]);
+
+            List<string> result = await TagsApplierUtil.ApplyTags(building, mockTagsApiConsumer);
+
+            ObjectTags objectTagsChild = child.GetComponent<ObjectTags>();
+            Assert.AreEqual(2, objectTagsChild.GetTags().Count);
+            Assert.AreEqual(mockApiTags[1].id, objectTagsChild.GetTags()[0].id);
+            Assert.AreEqual(mockApiTags[0].id, objectTagsChild.GetTags()[1].id);
             Assert.AreEqual(0, result.Count);
         }
 

--- a/Tests/EditorMode/TagsApplierUtilsTest.cs
+++ b/Tests/EditorMode/TagsApplierUtilsTest.cs
@@ -1,0 +1,209 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using ReupVirtualTwin.dataModels;
+using ReupVirtualTwin.editor;
+using ReupVirtualTwin.models;
+using ReupVirtualTwin.webRequestersInterfaces;
+using UnityEngine;
+using UnityEngine.TestTools;
+using System.Collections;
+
+
+namespace ReupVirtualTwinTests.editor
+{
+    public class TagsApplierUtilsTest
+    {
+        GameObject building;
+        List<Tag> mockApiTags;
+        MockTagsApiConsumer mockTagsApiConsumer;
+
+        private GameObject AddChildrenWithTags(GameObject parent, int childrenAmount)
+        {
+            parent.AddComponent<ObjectTags>();
+            for (int i = 0; i < childrenAmount; i++)
+            {
+                GameObject child = new GameObject($"TAG_{i}_tag_name");
+                child.AddComponent<ObjectTags>();
+                child.transform.parent = parent.transform;
+            }
+            return parent;
+        }
+
+        private GameObject AddChildrenWithoutTags(GameObject parent, int childrenAmount)
+        {
+            for (int i = 0; i < childrenAmount; i++)
+            {
+                GameObject child = new GameObject($"child_{i}");
+                child.transform.parent = parent.transform;
+            }
+            return parent;
+        }
+
+        private static List<Tag> CreateMockTags(int childAmount)
+        {
+            List<Tag> tags = new List<Tag>();
+            for (int i = 0; i < childAmount; i++)
+            {
+                tags.Add(new Tag()
+                {
+                    id = $"{i}",
+                    name = $"tag-{i}",
+                    description = $"tag-{i}",
+                    priority = i
+                });
+            }
+            return tags;
+        }
+
+        class MockTagsApiConsumer : ITagsApiConsumer
+        {
+            public List<Tag> mockApiTags;
+
+            public bool throwException = false;
+            public Task<PaginationResult<Tag>> GetTags()
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public Task<PaginationResult<Tag>> GetTags(int page)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public Task<PaginationResult<Tag>> GetTags(int page, int pageSize)
+            {
+                if (throwException)
+                {
+                    throw new System.Exception("Error fetching tags");
+                }
+                PaginationResult<Tag> requestResult = new PaginationResult<Tag>()
+                {
+                    count = mockApiTags.Count,
+                    next = null,
+                    previous = null,
+                    results = mockApiTags.ToArray()
+                };
+                return Task.FromResult(requestResult);
+            }
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            building = new GameObject("building");
+            mockApiTags = CreateMockTags(5);
+            mockTagsApiConsumer = new MockTagsApiConsumer() { mockApiTags = mockApiTags };
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            GameObject.DestroyImmediate(building);
+            mockApiTags.Clear();
+            mockTagsApiConsumer = null;
+        }
+
+        [Test]
+        public async Task ShouldNotApplyTagsIfGameObjectsHaveNoTagsInTheName()
+        {
+            AddChildrenWithoutTags(building, 5);
+
+            List<string> result = await TagsApplierUtil.ApplyTags(building, mockTagsApiConsumer);
+
+            for (int i = 0; i < 5; i++)
+            {
+                GameObject child = building.transform.GetChild(i).gameObject;
+                ObjectTags objectTags = child.GetComponent<ObjectTags>();
+                Assert.AreEqual(0, objectTags.GetTags().Count);
+            }
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [Test]
+        public async Task ShouldApplyTagsToAllChildren()
+        {
+            AddChildrenWithTags(building, 5);
+
+            List<string> result = await TagsApplierUtil.ApplyTags(building, mockTagsApiConsumer);
+
+            for (int i = 0; i < 5; i++)
+            {
+                GameObject child = building.transform.GetChild(i).gameObject;
+                ObjectTags objectTags = child.GetComponent<ObjectTags>();
+                Assert.IsNotNull(objectTags);
+                var tags = objectTags.GetTags();
+                Assert.AreEqual(1, tags.Count);
+                Assert.AreEqual(mockApiTags[i].id, tags[0].id);
+            }
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [Test]
+        public async Task ShouldApplyTagsToNestedObjects()
+        {
+            building = AddChildrenWithTags(building, 1);
+            GameObject child = building.transform.GetChild(0).gameObject;
+            AddChildrenWithTags(child, 1);
+            GameObject grandChild = child.transform.GetChild(0).gameObject;
+
+            List<string> result = await TagsApplierUtil.ApplyTags(building, mockTagsApiConsumer);
+
+            ObjectTags objectTagsChild = child.GetComponent<ObjectTags>();
+            ObjectTags objectTagsGrandChild = grandChild.GetComponent<ObjectTags>();
+
+            Assert.IsNotNull(objectTagsChild);
+            Assert.IsNotNull(objectTagsGrandChild);
+            Assert.AreEqual(1, objectTagsChild.GetTags().Count);
+            Assert.AreEqual(1, objectTagsGrandChild.GetTags().Count);
+            Assert.AreEqual(mockApiTags[0].id, objectTagsChild.GetTags()[0].id);
+            Assert.AreEqual(mockApiTags[0].id, objectTagsGrandChild.GetTags()[0].id);
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [Test]
+        public async Task ShouldApplyTagsOnlyToObjectsWhoseNamesContainTagsInsideNestedObjects()
+        {
+            building = AddChildrenWithoutTags(building, 1);
+            GameObject child = building.transform.GetChild(0).gameObject;
+            AddChildrenWithTags(child, 1);
+            GameObject grandChild = child.transform.GetChild(0).gameObject;
+
+            List<string> result = await TagsApplierUtil.ApplyTags(building, mockTagsApiConsumer);
+
+            ObjectTags objectTagsChild = child.GetComponent<ObjectTags>();
+            ObjectTags objectTagsGrandChild = grandChild.GetComponent<ObjectTags>();
+
+            Assert.AreEqual(0, objectTagsChild.GetTags().Count);
+            Assert.AreEqual(1, objectTagsGrandChild.GetTags().Count);
+            Assert.AreEqual(mockApiTags[0].id, objectTagsGrandChild.GetTags()[0].id);
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [Test]
+        public async Task ShouldReturnErrorMessagesIfTagsAreNotFound()
+        {
+            AddChildrenWithTags(building, 1);
+            mockApiTags.Clear();
+
+            List<string> result = await TagsApplierUtil.ApplyTags(building, mockTagsApiConsumer);
+
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual($"Tags Ids not found in 'TAG_0_tag_name': 0", result[0]);
+        }
+
+        [Test]
+        public async Task ShouldReturnErrorMessagesIfTagsApiConsumerThrowsException()
+        {
+            AddChildrenWithTags(building, 1);
+            mockTagsApiConsumer.throwException = true;
+
+            List<string> result = await TagsApplierUtil.ApplyTags(building, mockTagsApiConsumer);
+
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual("Error fetching tags", result[0]);
+        }
+
+
+    }
+}

--- a/Tests/EditorMode/TagsApplierUtilsTest.cs.meta
+++ b/Tests/EditorMode/TagsApplierUtilsTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 584036d33b4d48d488da3e3b33b11b7d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditorMode/reup.romulo.tests.editormode.asmdef
+++ b/Tests/EditorMode/reup.romulo.tests.editormode.asmdef
@@ -8,7 +8,9 @@
         "GUID:c8829a0ba3b964e4e9e556498da7797c",
         "GUID:cef0c762c8b945745aa202022a4beafb",
         "GUID:a94387ec035d5514c93dfbc1c4e15171",
-        "GUID:5f723ba0ce93eb64ca6f59169571c5ed"
+        "GUID:5f723ba0ce93eb64ca6f59169571c5ed",
+        "GUID:ef71f4f9d4e9ed44987e6a7778893414",
+        "GUID:2fff08516fe8b484ea0191f9747e8d2b"
     ],
     "includePlatforms": [
         "Editor"

--- a/Tests/TestMocks/DelayTagsWebRequesterSpy.cs
+++ b/Tests/TestMocks/DelayTagsWebRequesterSpy.cs
@@ -37,6 +37,14 @@ namespace ReupVirtualTwinTests.mocks
             await Task.Delay(delay);
             return returnPage;
         }
+
+        public async Task<PaginationResult<Tag>> GetTags(int page, int pageSize)
+        {
+            lastPageFetched = page;
+            numberOfTimesFetched++;
+            await Task.Delay(delay);
+            return returnPage;
+        }
     }
 }
 

--- a/Tests/TestMocks/EmptyStringsTagsWebRequesterSpy.cs
+++ b/Tests/TestMocks/EmptyStringsTagsWebRequesterSpy.cs
@@ -27,6 +27,12 @@ namespace ReupVirtualTwinTests.mocks
             return Task.FromResult(returnPage);
         }
 
+        public Task<PaginationResult<Tag>> GetTags(int page, int pageSize)
+        {
+            numberOfTimesFetched++;
+            return Task.FromResult(returnPage);
+        }
+
     }
 }
 

--- a/Tests/TestMocks/FailingTagsWebRequesterSpy.cs
+++ b/Tests/TestMocks/FailingTagsWebRequesterSpy.cs
@@ -18,5 +18,10 @@ namespace ReupVirtualTwinTests.mocks
         {
             throw new System.Exception("Error from FailingTagsWebRequesterSpy");
         }
+
+        public Task<PaginationResult<Tag>> GetTags(int page, int pageSize)
+        {
+            throw new System.Exception("Error from FailingTagsWebRequesterSpy");
+        }
     }
 }

--- a/Tests/TestMocks/TagsWebRequesterSpy.cs
+++ b/Tests/TestMocks/TagsWebRequesterSpy.cs
@@ -106,6 +106,22 @@ namespace ReupVirtualTwinTests.mocks
             }
             return Task.FromResult(thirdPage);
         }
+
+        public Task<PaginationResult<Tag>> GetTags(int page = 1, int pageSize = 3)
+        {
+            timesFetched++;
+            lastPageRequested = page;
+            lastPageSizeRequested = pageSize;
+            if (page == 1)
+            {
+                return Task.FromResult(firstPage);
+            }
+            if (page == 2)
+            {
+                return Task.FromResult(secondPage);
+            }
+            return Task.FromResult(thirdPage);
+        }
     }
 
 }


### PR DESCRIPTION
[Reup-498](https://macheight-reup.atlassian.net/browse/REUP-498)

As a designer, I want a tool that automates the process of adding tags to objects based on their names in SketchUp, so I can streamline my workflow and reduce manual tagging effort.

AC:

A tool exists within Unity that automatically applies tags to game objects based on their SketchUp names.

Tags are correctly applied to all relevant game objects.

if a tag is already present in a gameobjet that tag is not applied again.

Complex objects, like nested items (e.g., kitchen sets), are tagged accurately.

already existing tags in gameobjects are left intact when applying the referenced tags in the objects names.