### PR TITLE
Reup506 migrate actions tags

### DIFF
--- a/Editor/EditorSections/SelectTagsSection.cs
+++ b/Editor/EditorSections/SelectTagsSection.cs
@@ -86,7 +86,7 @@ namespace ReupVirtualTwin.editor
             {
                 allTags = new List<Tag>();
                 tagsApiManager.CleanTags();
-                await GetTags();
+                await tagsApiManager.GetTags();
             }
         }
 
@@ -124,17 +124,17 @@ namespace ReupVirtualTwin.editor
 
         private async Task GetTags()
         {
-            allTags = EditionTagsCreator.ApplyEditionTags(await tagsApiManager.GetTags());
+            allTags = await tagsApiManager.GetTags();
         }
 
         private async Task GetMoreTags()
         {
-            allTags = EditionTagsCreator.ApplyEditionTags(await tagsApiManager.LoadMoreTags());
+            allTags = await tagsApiManager.LoadMoreTags();
         }
 
         private bool IsTagAlreadyPresent(Tag tag)
         {
-            return selectedTags.Exists(presentTag => presentTag.name == tag.name);
+            return selectedTags.Exists(presentTag => presentTag.id == tag.id);
         }
 
     }

--- a/Editor/EditorUtils/TagsApplierUtil.cs
+++ b/Editor/EditorUtils/TagsApplierUtil.cs
@@ -18,7 +18,7 @@ namespace ReupVirtualTwin.editor
             try
             {
                 Tag[] apiTags = await fetchTags(tagsApiConsumer);
-                Dictionary<string, Tag> apiTagsDict = apiTags.ToDictionary(tag => tag.id);
+                Dictionary<int, Tag> apiTagsDict = apiTags.ToDictionary(tag => tag.id);
                 ApplyTagsToTree(building, apiTagsDict, errorMessages);
             }
             catch (Exception e)
@@ -37,7 +37,7 @@ namespace ReupVirtualTwin.editor
             return fetchedTagsResult.results;
         }
 
-        private static void ApplyTagsToTree(GameObject obj, Dictionary<string, Tag> apiTags, List<string> errorMessages)
+        private static void ApplyTagsToTree(GameObject obj, Dictionary<int, Tag> apiTags, List<string> errorMessages)
         {
             ApplyTagsToObject(obj, apiTags, errorMessages);
 
@@ -47,15 +47,15 @@ namespace ReupVirtualTwin.editor
             }
         }
 
-        private static void ApplyTagsToObject(GameObject obj, Dictionary<string, Tag> apiTags, List<string> errorMessages)
+        private static void ApplyTagsToObject(GameObject obj, Dictionary<int, Tag> apiTags, List<string> errorMessages)
         {
-            List<string> objectTagsIds = ExtractTagsIdsFromObject(obj);            
+            List<int> objectTagsIds = ExtractTagsIdsFromObject(obj);            
             List<Tag> tagsToApply = objectTagsIds
                 .Where(id => apiTags.TryGetValue(id, out _))
                 .Select(id => apiTags[id])
                 .ToList();
 
-            List<string> notFoundTagsIds = objectTagsIds.Where(id => tagsToApply.All(tag => tag.id != id)).ToList();
+            List<int> notFoundTagsIds = objectTagsIds.Where(id => tagsToApply.All(tag => tag.id != id)).ToList();
             if (notFoundTagsIds.Count > 0)
             {
                 string notFoundTagIdsStr = string.Join(" - ", notFoundTagsIds);
@@ -63,19 +63,19 @@ namespace ReupVirtualTwin.editor
             }
 
             ObjectTags objectTags = obj.GetComponent<ObjectTags>() ?? obj.gameObject.AddComponent<ObjectTags>();
-            Dictionary<string, Tag> existingTagsDict = objectTags.GetTags().ToDictionary(tag => tag.id);
+            Dictionary<int, Tag> existingTagsDict = objectTags.GetTags().ToDictionary(tag => tag.id);
             List<Tag> tagsToAdd = tagsToApply.Where(tag => !existingTagsDict.ContainsKey(tag.id)).ToList();
 
             objectTags.AddTags(tagsToAdd.ToArray());
         }
 
-        private static List<string> ExtractTagsIdsFromObject(GameObject gameObject)
+        private static List<int> ExtractTagsIdsFromObject(GameObject gameObject)
         {   
             var tagRegex = new Regex(@"TAG_(\d+)", RegexOptions.Compiled);
             return tagRegex.Matches(gameObject.name)
                           .Cast<Match>()
                           .Where(match => match.Success)
-                          .Select(match => match.Groups[1].Value)
+                          .Select(match => int.Parse(match.Groups[1].Value))
                           .ToList();
         }
     }

--- a/Editor/ObjectTagsEditor.cs
+++ b/Editor/ObjectTagsEditor.cs
@@ -81,7 +81,7 @@ namespace ReupVirtualTwin.editor
 
         private List<Tag> GetCommonTags()
         {
-            HashSet<string> commonTagNames = new HashSet<string>(objectTagsList[0].tags.Select(t => t.id));
+            HashSet<int> commonTagNames = new HashSet<int>(objectTagsList[0].tags.Select(t => t.id));
             for (int i = 1; i < objectTagsList.Count; i++)
             {
                 commonTagNames.IntersectWith(objectTagsList[i].tags.Select(t => t.id));
@@ -94,7 +94,7 @@ namespace ReupVirtualTwin.editor
 
         private List<Tag> GetDifferentTags()
         {
-            var commonTagNames = new HashSet<string>(GetCommonTags().Select(t => t.id));
+            var commonTagNames = new HashSet<int>(GetCommonTags().Select(t => t.id));
             var differentTags = objectTagsList
                 .SelectMany(objectTags => objectTags.tags)
                 .Where(t => !commonTagNames.Contains(t.id))

--- a/Runtime/Behaviours/SetupBuilding.cs
+++ b/Runtime/Behaviours/SetupBuilding.cs
@@ -2,7 +2,6 @@ using UnityEngine;
 using System;
 using ReupVirtualTwin.behaviourInterfaces;
 using ReupVirtualTwin.helperInterfaces;
-using ReupVirtualTwin.controllerInterfaces;
 using ReupVirtualTwin.helpers;
 using ReupVirtualTwin.enums;
 using Zenject;

--- a/Runtime/Controllers/TagsController.cs
+++ b/Runtime/Controllers/TagsController.cs
@@ -21,7 +21,7 @@ namespace ReupVirtualTwin.controllers
             return objectTags.AddTag(tag);
         }
 
-        public bool DoesObjectHaveTag(GameObject obj, string tagId)
+        public bool DoesObjectHaveTag(GameObject obj, int tagId)
         {
             List<Tag> tags = GetTagsFromObject(obj);
             if (tags == null) return false;

--- a/Runtime/ControllersInterfaces/ITagsController.cs
+++ b/Runtime/ControllersInterfaces/ITagsController.cs
@@ -9,7 +9,7 @@ namespace ReupVirtualTwin.controllerInterfaces
         public List<Tag> GetTagsFromObject(GameObject obj);
         public List<Tag> AddTagToObject(GameObject obj, Tag tag);
         public List<Tag> RemoveTagFromObject(GameObject obj, Tag tag);
-        public bool DoesObjectHaveTag(GameObject obj, string tagId);
+        public bool DoesObjectHaveTag(GameObject obj, int tagId);
         public string[] GetTagNamesFromObject(GameObject obj);
     }
 }

--- a/Runtime/DataModels/Tag.cs
+++ b/Runtime/DataModels/Tag.cs
@@ -5,7 +5,7 @@ namespace ReupVirtualTwin.dataModels
     [Serializable]
     public class Tag
     {
-        public string id;
+        public int id;
         public string name;
         public string description;
         public int priority;

--- a/Runtime/Helpers/EditionTagsCreator.cs
+++ b/Runtime/Helpers/EditionTagsCreator.cs
@@ -18,7 +18,7 @@ namespace ReupVirtualTwin.helpers
         {
             return new Tag()
             {
-                id = "action-deletable",
+                id = 234,
                 name = EditionTag.DELETABLE.ToString(),
                 description = "this is an action tag burn into unity"
             };
@@ -27,7 +27,7 @@ namespace ReupVirtualTwin.helpers
         {
             return new Tag()
             {
-                id = "action-transformable",
+                id = 233,
                 name = EditionTag.TRANSFORMABLE.ToString(),
                 description = "this is an action tag burn into unity"
             };
@@ -36,15 +36,10 @@ namespace ReupVirtualTwin.helpers
         {
             return new Tag()
             {
-                id = "action-selectable",
+                id = 232,
                 name = EditionTag.SELECTABLE.ToString(),
                 description = "this is an action tag burn into unity"
             };
-        }
-
-        public static List<Tag> ApplyEditionTags(List<Tag> tags)
-        {
-            return EditionTagsCreator.CreateEditionTags().Concat(tags).ToList();
         }
     }
 }

--- a/Runtime/WebRequesters/TagsApiConsumer.cs
+++ b/Runtime/WebRequesters/TagsApiConsumer.cs
@@ -9,8 +9,7 @@ namespace ReupVirtualTwin.webRequesters
 {
     public class TagsApiConsumer : ITagsApiConsumer
     {
-        // private string baseUrl = "https://api-prod-reup.macheight.com/api/v1/";
-        private string baseUrl = "http://localhost:8000/api/v1/";
+        private string baseUrl = "https://api-prod-reup.macheight.com/api/v1/";
 
         public Task<PaginationResult<Tag>> GetTags()
         {

--- a/Runtime/WebRequesters/TagsApiConsumer.cs
+++ b/Runtime/WebRequesters/TagsApiConsumer.cs
@@ -9,7 +9,8 @@ namespace ReupVirtualTwin.webRequesters
 {
     public class TagsApiConsumer : ITagsApiConsumer
     {
-        private string baseUrl = "https://api-prod-reup.macheight.com/api/v1/";
+        // private string baseUrl = "https://api-prod-reup.macheight.com/api/v1/";
+        private string baseUrl = "http://localhost:8000/api/v1/";
 
         public Task<PaginationResult<Tag>> GetTags()
         {

--- a/Tests/EditorMode/TagsApplierUtilsTest.cs
+++ b/Tests/EditorMode/TagsApplierUtilsTest.cs
@@ -39,22 +39,6 @@ namespace ReupVirtualTwinTests.editor
             return parent;
         }
 
-        // private static List<Tag> CreateMockTags(int childAmount)
-        // {
-        //     List<Tag> tags = new List<Tag>();
-        //     for (int i = 0; i < childAmount; i++)
-        //     {
-        //         tags.Add(new Tag()
-        //         {
-        //             id = $"{i}",
-        //             name = $"tag-{i}",
-        //             description = $"tag-{i}",
-        //             priority = i
-        //         });
-        //     }
-        //     return tags;
-        // }
-
         class MockTagsApiConsumer : ITagsApiConsumer
         {
             public List<Tag> mockApiTags;

--- a/Tests/EditorMode/TagsApplierUtilsTest.cs
+++ b/Tests/EditorMode/TagsApplierUtilsTest.cs
@@ -6,8 +6,7 @@ using ReupVirtualTwin.editor;
 using ReupVirtualTwin.models;
 using ReupVirtualTwin.webRequestersInterfaces;
 using UnityEngine;
-using UnityEngine.TestTools;
-using System.Collections;
+using ReupVirtualTwinTests.utils;
 
 
 namespace ReupVirtualTwinTests.editor
@@ -40,21 +39,21 @@ namespace ReupVirtualTwinTests.editor
             return parent;
         }
 
-        private static List<Tag> CreateMockTags(int childAmount)
-        {
-            List<Tag> tags = new List<Tag>();
-            for (int i = 0; i < childAmount; i++)
-            {
-                tags.Add(new Tag()
-                {
-                    id = $"{i}",
-                    name = $"tag-{i}",
-                    description = $"tag-{i}",
-                    priority = i
-                });
-            }
-            return tags;
-        }
+        // private static List<Tag> CreateMockTags(int childAmount)
+        // {
+        //     List<Tag> tags = new List<Tag>();
+        //     for (int i = 0; i < childAmount; i++)
+        //     {
+        //         tags.Add(new Tag()
+        //         {
+        //             id = $"{i}",
+        //             name = $"tag-{i}",
+        //             description = $"tag-{i}",
+        //             priority = i
+        //         });
+        //     }
+        //     return tags;
+        // }
 
         class MockTagsApiConsumer : ITagsApiConsumer
         {
@@ -92,7 +91,7 @@ namespace ReupVirtualTwinTests.editor
         public void SetUp()
         {
             building = new GameObject("building");
-            mockApiTags = CreateMockTags(5);
+            mockApiTags = TagFactory.CreateBulk(5, TagFactory.CreateFaker());
             mockTagsApiConsumer = new MockTagsApiConsumer() { mockApiTags = mockApiTags };
         }
 

--- a/Tests/Instantiators.meta
+++ b/Tests/Instantiators.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8e68c48c8bc59e34baab08c60b567bea
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Instantiators/ReupSceneInstantiator.cs
+++ b/Tests/Instantiators/ReupSceneInstantiator.cs
@@ -7,13 +7,13 @@ using UnityEngine.InputSystem;
 using ReupVirtualTwin.models;
 using ReupVirtualTwin.helpers;
 using ReupVirtualTwin.managerInterfaces;
-using ReupVirtualTwinTests.mocks;
 using Zenject;
 using ReupVirtualTwin.dependencyInjectors;
 using ReupVirtualTwin.controllerInterfaces;
 using ReupVirtualTwin.controllers;
+using ReupVirtualTwinTests.mocks;
 
-namespace ReupVirtualTwinTests.utils
+namespace ReupVirtualTwinTests.instantiators
 {
     public static class ReupSceneInstantiator
     {

--- a/Tests/Instantiators/ReupSceneInstantiator.cs.meta
+++ b/Tests/Instantiators/ReupSceneInstantiator.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0341b168cad81fa46a716ea8eee1356e
+guid: 00c9fc2921afd8d4697c7d129506aa2b
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Tests/Instantiators/reup.romulo.tests.instantiators.asmdef
+++ b/Tests/Instantiators/reup.romulo.tests.instantiators.asmdef
@@ -1,0 +1,28 @@
+{
+    "name": "reup.romulo.tests.instantiators",
+    "rootNamespace": "",
+    "references": [
+        "GUID:db1051acd1be67444bdd582f8c8da4bd",
+        "GUID:51949aeab7ddd114ea276b96726cb4bb",
+        "GUID:75469ad4d38634e559750d17036d5f7c",
+        "GUID:5f723ba0ce93eb64ca6f59169571c5ed",
+        "GUID:f423d50bd16e5af44b5de6fb9aa6914c",
+        "GUID:993f0e698e8fb354b8eee1296bc5f2f6",
+        "GUID:15c1dcf2b670848439ceff09bf17acd2",
+        "GUID:1f8fa41a8be0a6f4e8779e83989ae122",
+        "GUID:716a66b966d7f4d4dbe82763abab9053",
+        "GUID:1772869efacc54544ac5d329d23fc591",
+        "GUID:0da6763f50b07ec4c9363bdf3985cee5",
+        "GUID:dc04f38471c3a459fb4d31124ee9127d",
+        "GUID:40b5750f5722c3a489ac791a57baac05"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Tests/Instantiators/reup.romulo.tests.instantiators.asmdef
+++ b/Tests/Instantiators/reup.romulo.tests.instantiators.asmdef
@@ -16,7 +16,9 @@
         "GUID:dc04f38471c3a459fb4d31124ee9127d",
         "GUID:40b5750f5722c3a489ac791a57baac05"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/Tests/Instantiators/reup.romulo.tests.instantiators.asmdef.meta
+++ b/Tests/Instantiators/reup.romulo.tests.instantiators.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6458a780beb514e4991801f541c6d3d6
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/ChangeColorObjectsTest.cs
+++ b/Tests/PlayMode/ChangeColorObjectsTest.cs
@@ -10,6 +10,7 @@ using ReupVirtualTwin.modelInterfaces;
 using ReupVirtualTwin.helpers;
 using Newtonsoft.Json.Linq;
 using ReupVirtualTwinTests.utils;
+using ReupVirtualTwinTests.instantiators;
 
 public class ChangeColorObjectsTest : MonoBehaviour
 {

--- a/Tests/PlayMode/ChangeHeightTest.cs
+++ b/Tests/PlayMode/ChangeHeightTest.cs
@@ -1,11 +1,11 @@
 using NUnit.Framework;
 using ReupVirtualTwin.behaviours;
-using ReupVirtualTwinTests.utils;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.TestTools;
 using UnityEditor;
+using ReupVirtualTwinTests.instantiators;
 
 
 namespace ReupVirtualTwinTests.behaviours

--- a/Tests/PlayMode/CharacterPositionManagerTest.cs
+++ b/Tests/PlayMode/CharacterPositionManagerTest.cs
@@ -4,8 +4,7 @@ using UnityEngine;
 using UnityEngine.TestTools;
 
 using ReupVirtualTwin.managers;
-using ReupVirtualTwinTests.utils;
-using ReupVirtualTwin.managerInterfaces;
+using ReupVirtualTwinTests.instantiators;
 
 public class CharacterPositionManagerTest : MonoBehaviour
 {

--- a/Tests/PlayMode/CollisionDetectorTest.cs
+++ b/Tests/PlayMode/CollisionDetectorTest.cs
@@ -4,9 +4,9 @@ using UnityEngine.TestTools;
 using UnityEditor;
 using System.Collections;
 
-using ReupVirtualTwinTests.utils;
 using ReupVirtualTwin.managerInterfaces;
 using UnityEngine.InputSystem;
+using ReupVirtualTwinTests.instantiators;
 
 public class CollisionDetectorTest : MonoBehaviour
 {

--- a/Tests/PlayMode/EditMediatorTest.cs
+++ b/Tests/PlayMode/EditMediatorTest.cs
@@ -18,6 +18,7 @@ using ReupVirtualTwin.controllerInterfaces;
 using ReupVirtualTwin.dataSchemas;
 using Newtonsoft.Json.Schema;
 using ReupVirtualTwinTests.mocks;
+using ReupVirtualTwinTests.utils;
 
 public class EditMediatorTest : MonoBehaviour
 {
@@ -241,7 +242,7 @@ public class EditMediatorTest : MonoBehaviour
             building = new ObjectDTO
             {
                 id = "building-id",
-                tags = new Tag[2] { new Tag() { id = "tag0" }, new Tag() { id = "tag1" } },
+                tags = TagFactory.CreateBulk(2).ToArray(),
             };
         }
 
@@ -356,12 +357,12 @@ public class EditMediatorTest : MonoBehaviour
             new ObjectDTO
             {
                 id = "id0",
-                tags = new Tag[2]{ new Tag() { id = "tag0"},  new Tag() { id = "tag1"} },
+                tags = TagFactory.CreateBulk(2).ToArray(),
             },
             new ObjectDTO
             {
                 id = "id1",
-                tags = new Tag[2]{ new Tag() { id = "tag2"},  new Tag() { id = "tag3"} },
+                tags = TagFactory.CreateBulk(2).ToArray(),
             },
         };
 

--- a/Tests/PlayMode/GesturesManagerTest.cs
+++ b/Tests/PlayMode/GesturesManagerTest.cs
@@ -1,7 +1,7 @@
 using System.Collections;
 using NUnit.Framework;
 using ReupVirtualTwin.managers;
-using ReupVirtualTwinTests.utils;
+using ReupVirtualTwinTests.instantiators;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.TestTools;

--- a/Tests/PlayMode/HighlightSelectableObjectTest.cs
+++ b/Tests/PlayMode/HighlightSelectableObjectTest.cs
@@ -5,7 +5,7 @@ using UnityEngine.TestTools;
 
 using ReupVirtualTwin.behaviours;
 using ReupVirtualTwin.managerInterfaces;
-using ReupVirtualTwinTests.utils;
+using ReupVirtualTwinTests.instantiators;
 
 namespace ReupVirtualTwinTests
 {

--- a/Tests/PlayMode/IdControllerTest.cs
+++ b/Tests/PlayMode/IdControllerTest.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 using ReupVirtualTwin.models;
 using ReupVirtualTwin.modelInterfaces;
 using ReupVirtualTwin.controllers;
-using ReupVirtualTwinTests.utils;
+using ReupVirtualTwinTests.instantiators;
 
 namespace ReupVirtualTwinTests.Registry
 {

--- a/Tests/PlayMode/InitialSpawnTest.cs
+++ b/Tests/PlayMode/InitialSpawnTest.cs
@@ -1,9 +1,9 @@
 using NUnit.Framework;
-using ReupVirtualTwinTests.utils;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEditor;
+using ReupVirtualTwinTests.instantiators;
 
 namespace ReupVirtualTwinTests.behaviours
 {

--- a/Tests/PlayMode/InsertObjectControllerTest.cs
+++ b/Tests/PlayMode/InsertObjectControllerTest.cs
@@ -14,9 +14,9 @@ using ReupVirtualTwin.managerInterfaces;
 using ReupVirtualTwin.webRequestersInterfaces;
 using System.Collections;
 using ReupVirtualTwin.helpers;
-using ReupVirtualTwinTests.utils;
 using ReupVirtualTwin.models;
 using Newtonsoft.Json.Linq;
+using ReupVirtualTwinTests.instantiators;
 
 namespace ReupVirtualTwinTests.controllers
 {

--- a/Tests/PlayMode/MaintainHeightTest.cs
+++ b/Tests/PlayMode/MaintainHeightTest.cs
@@ -5,8 +5,7 @@ using UnityEditor;
 using System.Collections;
 
 using ReupVirtualTwin.behaviours;
-using ReupVirtualTwin.managerInterfaces;
-using ReupVirtualTwinTests.utils;
+using ReupVirtualTwinTests.instantiators;
 
 
 public class MaintainHeightTest : MonoBehaviour

--- a/Tests/PlayMode/ModelInfoManagerTest.cs
+++ b/Tests/PlayMode/ModelInfoManagerTest.cs
@@ -12,6 +12,7 @@ using NUnit.Framework;
 using ReupVirtualTwinTests.utils;
 using ReupVirtualTwin.modelInterfaces;
 using ReupVirtualTwin.models;
+using ReupVirtualTwinTests.instantiators;
 
 public class ModelInfoManagerTest : MonoBehaviour
 {

--- a/Tests/PlayMode/ModelInfoRequestTest.cs
+++ b/Tests/PlayMode/ModelInfoRequestTest.cs
@@ -13,6 +13,7 @@ using ReupVirtualTwinTests.utils;
 using ReupVirtualTwinTests.mocks;
 using ReupVirtualTwin.controllers;
 using ReupVirtualTwin.controllerInterfaces;
+using ReupVirtualTwinTests.instantiators;
 
 namespace ReupVirtualTwinTests.IOTests
 {

--- a/Tests/PlayMode/MoveCharacterTest.cs
+++ b/Tests/PlayMode/MoveCharacterTest.cs
@@ -7,6 +7,7 @@ using InSys = UnityEngine.InputSystem;
 using UnityEngine.InputSystem;
 using UnityEngine.TestTools;
 using UnityEditor;
+using ReupVirtualTwinTests.instantiators;
 
 namespace ReupVirtualTwinTests.behaviours
 {

--- a/Tests/PlayMode/MoveDollhouseViewTest.cs
+++ b/Tests/PlayMode/MoveDollhouseViewTest.cs
@@ -6,6 +6,7 @@ using UnityEngine.InputSystem;
 using UnityEngine.TestTools;
 using UnityEditor;
 using ReupVirtualTwin.helpers;
+using ReupVirtualTwinTests.instantiators;
 
 
 namespace ReupVirtualTwinTests.behaviours

--- a/Tests/PlayMode/ObjectRegistryTests.cs
+++ b/Tests/PlayMode/ObjectRegistryTests.cs
@@ -4,7 +4,7 @@ using UnityEngine.TestTools;
 using NUnit.Framework;
 using ReupVirtualTwin.models;
 using ReupVirtualTwin.modelInterfaces;
-using ReupVirtualTwinTests.utils;
+using ReupVirtualTwinTests.instantiators;
 using System;
 
 namespace ReupVirtualTwinTests.Registry

--- a/Tests/PlayMode/ObjectTagsTest.cs
+++ b/Tests/PlayMode/ObjectTagsTest.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 
 using ReupVirtualTwin.models;
 using ReupVirtualTwin.dataModels;
+using ReupVirtualTwinTests.utils;
 
 
 public class ObjectTagsTest : MonoBehaviour
@@ -18,7 +19,7 @@ public class ObjectTagsTest : MonoBehaviour
     {
         containerGameObject = new GameObject("container");
         objectTags = containerGameObject.AddComponent<ObjectTags>();
-        testTag = new Tag() { id = "tag-id" };
+        testTag = TagFactory.Create();
     }
     [TearDown]
     public void TearDown()

--- a/Tests/PlayMode/ObjectsTexturesRecordTest.cs
+++ b/Tests/PlayMode/ObjectsTexturesRecordTest.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 using ReupVirtualTwin.controllers;
 using ReupVirtualTwin.modelInterfaces;
 using ReupVirtualTwin.models;
-using ReupVirtualTwinTests.utils;
+using ReupVirtualTwinTests.instantiators;
 using UnityEngine;
 using UnityEngine.TestTools;
 

--- a/Tests/PlayMode/OriginalSceneControllerTest.cs
+++ b/Tests/PlayMode/OriginalSceneControllerTest.cs
@@ -7,8 +7,8 @@ using UnityEditor;
 using ReupVirtualTwin.modelInterfaces;
 using ReupVirtualTwin.controllers;
 using ReupVirtualTwin.models;
-using ReupVirtualTwinTests.utils;
 using ReupVirtualTwinTests.mocks;
+using ReupVirtualTwinTests.instantiators;
 
 namespace ReupVirtualTwinTests.controllers
 {

--- a/Tests/PlayMode/RegisteredIdentifierTest.cs
+++ b/Tests/PlayMode/RegisteredIdentifierTest.cs
@@ -4,7 +4,7 @@ using ReupVirtualTwin.models;
 using ReupVirtualTwin.modelInterfaces;
 using UnityEngine;
 using UnityEngine.TestTools;
-using ReupVirtualTwinTests.utils;
+using ReupVirtualTwinTests.instantiators;
 
 namespace ReupVirtualTwinTests.Registry
 {

--- a/Tests/PlayMode/ReupPrefabTest.cs
+++ b/Tests/PlayMode/ReupPrefabTest.cs
@@ -3,13 +3,14 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 
+using ReupVirtualTwinTests.instantiators;
 using ReupVirtualTwin.managers;
 using ReupVirtualTwin.modelInterfaces;
 using ReupVirtualTwin.helpers;
 using ReupVirtualTwin.managerInterfaces;
 using ReupVirtualTwin.helperInterfaces;
-using ReupVirtualTwinTests.utils;
 using ReupVirtualTwin.enums;
+using ReupVirtualTwinTests.mocks;
 
 public class ReupPrefabTest : MonoBehaviour
 {

--- a/Tests/PlayMode/RotateCharacterTest.cs
+++ b/Tests/PlayMode/RotateCharacterTest.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using ReupVirtualTwin.helpers;
+using ReupVirtualTwinTests.instantiators;
 using ReupVirtualTwinTests.utils;
 using System.Collections;
 using UnityEngine;

--- a/Tests/PlayMode/RotateDollhouseViewTest.cs
+++ b/Tests/PlayMode/RotateDollhouseViewTest.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using ReupVirtualTwin.behaviours;
 using ReupVirtualTwin.enums;
 using ReupVirtualTwin.helpers;
+using ReupVirtualTwinTests.instantiators;
 using ReupVirtualTwinTests.utils;
 using Unity.Cinemachine;
 using UnityEngine;

--- a/Tests/PlayMode/SetupBuildingTest.cs
+++ b/Tests/PlayMode/SetupBuildingTest.cs
@@ -1,10 +1,10 @@
 using UnityEngine;
 using NUnit.Framework;
 using ReupVirtualTwin.models;
-using ReupVirtualTwinTests.utils;
 using ReupVirtualTwin.behaviours;
 using UnityEngine.TestTools;
 using System.Collections;
+using ReupVirtualTwinTests.instantiators;
 
 namespace ReupVirtualTwinTests.behaviours
 {

--- a/Tests/PlayMode/SlideToSpaceTest.cs
+++ b/Tests/PlayMode/SlideToSpaceTest.cs
@@ -12,6 +12,7 @@ using Newtonsoft.Json;
 using ReupVirtualTwin.dataModels;
 using ReupVirtualTwinTests.utils;
 using ReupVirtualTwinTests.mocks;
+using ReupVirtualTwinTests.instantiators;
 
 namespace ReupVirtualTwinTests.IOTests
 {

--- a/Tests/PlayMode/SphereMaterialContainerHandlerTest.cs
+++ b/Tests/PlayMode/SphereMaterialContainerHandlerTest.cs
@@ -7,7 +7,8 @@ using ReupVirtualTwin.enums;
 using UnityEditor;
 using ReupVirtualTwin.models;
 using ReupVirtualTwin.helpers;
-using ReupVirtualTwinTests.utils;
+using ReupVirtualTwinTests.mocks;
+using ReupVirtualTwinTests.instantiators;
 
 public class SphereMaterialContainerHandlerTest
 {

--- a/Tests/PlayMode/SwitchViewModeTest.cs
+++ b/Tests/PlayMode/SwitchViewModeTest.cs
@@ -8,7 +8,7 @@ using ReupVirtualTwin.managers;
 using ReupVirtualTwin.enums;
 using Newtonsoft.Json;
 using ReupVirtualTwin.dataModels;
-using ReupVirtualTwinTests.utils;
+using ReupVirtualTwinTests.instantiators;
 using ReupVirtualTwinTests.mocks;
 using System.Linq;
 

--- a/Tests/PlayMode/TagControllerTest.cs
+++ b/Tests/PlayMode/TagControllerTest.cs
@@ -5,10 +5,9 @@ using UnityEngine.TestTools;
 using NUnit.Framework;
 
 using ReupVirtualTwin.models;
-using ReupVirtualTwin.enums;
-using ReupVirtualTwin.behaviours;
 using ReupVirtualTwin.controllers;
 using ReupVirtualTwin.dataModels;
+using ReupVirtualTwinTests.utils;
 
 public class tagsControllerTest : MonoBehaviour
 {
@@ -18,9 +17,7 @@ public class tagsControllerTest : MonoBehaviour
     TagsController tagsController;
     ObjectTags objectTags0;
     ObjectTags objectTags1;
-    Tag tag0 = new Tag() { id = "tag0", name = "tag0" };
-    Tag tag1 = new Tag() { id = "tag1", name = "tag1" };
-    Tag tag2 = new Tag() { id = "tag2", name = "tag2" };
+    List<Tag> tags = TagFactory.CreateBulk(3);
 
     [SetUp]
     public void SetUp()
@@ -28,10 +25,10 @@ public class tagsControllerTest : MonoBehaviour
         tagsController = new TagsController();
         taggedObject0 = new GameObject("taggedObj0");
         objectTags0 = taggedObject0.AddComponent<ObjectTags>();
-        objectTags0.AddTags(new Tag[2] {tag0, tag1});
+        objectTags0.AddTags(new Tag[2] {tags[0], tags[1]});
         taggedObject1 = new GameObject("taggedObject1");
         objectTags1 = taggedObject1.AddComponent<ObjectTags>();
-        objectTags1.AddTag(tag0);
+        objectTags1.AddTag(tags[0]);
         nonTaggedObject0 = new GameObject("nonTaggedObj0");
     }
     [TearDown]
@@ -44,34 +41,34 @@ public class tagsControllerTest : MonoBehaviour
     [UnityTest]
     public IEnumerator ShouldReturnFalseOnCheckForTags()
     {
-        Assert.IsFalse(tagsController.DoesObjectHaveTag(taggedObject0, tag2.id));
-        Assert.IsFalse(tagsController.DoesObjectHaveTag(taggedObject1, tag2.id));
-        Assert.IsFalse(tagsController.DoesObjectHaveTag(nonTaggedObject0, tag2.id));
+        Assert.IsFalse(tagsController.DoesObjectHaveTag(taggedObject0, tags[2].id));
+        Assert.IsFalse(tagsController.DoesObjectHaveTag(taggedObject1, tags[2].id));
+        Assert.IsFalse(tagsController.DoesObjectHaveTag(nonTaggedObject0, tags[2].id));
         yield return null;
     }
     [UnityTest]
     public IEnumerator ShouldReturnTrueOnCheckForTags()
     {
-        Assert.IsTrue(tagsController.DoesObjectHaveTag(taggedObject0, tag0.id));
-        Assert.IsTrue(tagsController.DoesObjectHaveTag(taggedObject1, tag0.id));
+        Assert.IsTrue(tagsController.DoesObjectHaveTag(taggedObject0, tags[0].id));
+        Assert.IsTrue(tagsController.DoesObjectHaveTag(taggedObject1, tags[0].id));
         yield return null;
     }
     [UnityTest]
     public IEnumerator ShouldAddTags()
     {
-        Assert.IsFalse(tagsController.DoesObjectHaveTag(taggedObject0, tag2.id));
-        tagsController.AddTagToObject(taggedObject0, tag2);
+        Assert.IsFalse(tagsController.DoesObjectHaveTag(taggedObject0, tags[2].id));
+        tagsController.AddTagToObject(taggedObject0, tags[2]);
         yield return null;
-        Assert.IsTrue(tagsController.DoesObjectHaveTag(taggedObject0, tag2.id));
+        Assert.IsTrue(tagsController.DoesObjectHaveTag(taggedObject0, tags[2].id));
         yield return null;
     }
     [UnityTest]
     public IEnumerator ShouldRemoveTags()
     {
-        Assert.IsTrue(tagsController.DoesObjectHaveTag(taggedObject0, tag0.id));
-        tagsController.RemoveTagFromObject(taggedObject0, tag0);
+        Assert.IsTrue(tagsController.DoesObjectHaveTag(taggedObject0, tags[0].id));
+        tagsController.RemoveTagFromObject(taggedObject0, tags[0]);
         yield return null;
-        Assert.IsFalse(tagsController.DoesObjectHaveTag(taggedObject0, tag0.id));
+        Assert.IsFalse(tagsController.DoesObjectHaveTag(taggedObject0, tags[0].id));
         yield return null;
     }
 

--- a/Tests/PlayMode/TagFiltersTest.cs
+++ b/Tests/PlayMode/TagFiltersTest.cs
@@ -4,6 +4,8 @@ using NUnit.Framework;
 using ReupVirtualTwin.models;
 using ReupVirtualTwin.controllers;
 using ReupVirtualTwin.dataModels;
+using System.Collections.Generic;
+using ReupVirtualTwinTests.utils;
 
 namespace ReupVirtualTwinTests.controllers
 {
@@ -11,18 +13,16 @@ namespace ReupVirtualTwinTests.controllers
     {
         GameObject taggedObject0;
         GameObject taggedObject1;
-        Tag tag0;
-        Tag tag1;
+        List<Tag> tags;
 
         [SetUp]
         public void SetUp()
         {
-            tag0 = new Tag() { id = "tag0", name = "tag0" };
-            tag1 = new Tag() { id = "tag1", name = "tag1" };
+            tags = TagFactory.CreateBulk(2);
             taggedObject0 = new GameObject("taggedObj0");
-            taggedObject0.AddComponent<ObjectTags>().AddTag(tag0);
+            taggedObject0.AddComponent<ObjectTags>().AddTag(tags[0]);
             taggedObject1 = new GameObject("taggedObject1");
-            taggedObject1.AddComponent<ObjectTags>().AddTags(new Tag[2] { tag0, tag1 });
+            taggedObject1.AddComponent<ObjectTags>().AddTags(new Tag[2] { tags[0], tags[1] });
         }
         [TearDown]
         public void TearDown()
@@ -33,15 +33,15 @@ namespace ReupVirtualTwinTests.controllers
         [Test]
         public void FilterDisplayText_ShouldBeTagName()
         {
-            TagFilter filter0 = new TagFilter(tag0);
-            Assert.AreEqual(filter0.displayText, $"{tag0.id} {tag0.name}");
-            TagFilter filter1 = new TagFilter(tag1);
-            Assert.AreEqual(filter1.displayText, $"{tag1.id} {tag1.name}");
+            TagFilter filter0 = new TagFilter(tags[0]);
+            Assert.AreEqual(filter0.displayText, $"{tags[0].id} {tags[0].name}");
+            TagFilter filter1 = new TagFilter(tags[1]);
+            Assert.AreEqual(filter1.displayText, $"{tags[1].id} {tags[1].name}");
         }
         [Test]
         public void FilterTagShouldCallOnRemoveCallback()
         {
-            TagFilter filter0 = new TagFilter(tag0);
+            TagFilter filter0 = new TagFilter(tags[0]);
             bool callbackCalled = false;
             Assert.IsFalse(callbackCalled);
             filter0.onRemoveFilter = () => { callbackCalled = true; };

--- a/Tests/PlayMode/TagsApiManagerTest.cs
+++ b/Tests/PlayMode/TagsApiManagerTest.cs
@@ -32,9 +32,9 @@ public class TagsApiManagerTest : MonoBehaviour
         tagsApiManager.tagsApiConsumer = tagsWebRequesterSpy;
         List<Tag> initialTags = await tagsApiManager.GetTags();
         Assert.AreEqual(3, initialTags.Count);
-        Assert.AreEqual("tag0", initialTags[0].name);
-        Assert.AreEqual("tag1", initialTags[1].name);
-        Assert.AreEqual("tag2", initialTags[2].name);
+        Assert.AreEqual(tagsWebRequesterSpy.firstPage.results[0].name, initialTags[0].name);
+        Assert.AreEqual(tagsWebRequesterSpy.firstPage.results[1].name, initialTags[1].name);
+        Assert.AreEqual(tagsWebRequesterSpy.firstPage.results[2].name, initialTags[2].name);
         Assert.AreEqual(1, tagsWebRequesterSpy.lastPageRequested);
         Assert.AreEqual(1, tagsWebRequesterSpy.timesFetched);
     }
@@ -48,9 +48,9 @@ public class TagsApiManagerTest : MonoBehaviour
         Assert.AreEqual(1, tagsWebRequesterSpy.lastPageRequested);
         List<Tag> initialTags = await tagsApiManager.GetTags();
         Assert.AreEqual(3, initialTags.Count);
-        Assert.AreEqual("tag0", initialTags[0].name);
-        Assert.AreEqual("tag1", initialTags[1].name);
-        Assert.AreEqual("tag2", initialTags[2].name);
+        Assert.AreEqual(tagsWebRequesterSpy.firstPage.results[0].name, initialTags[0].name);
+        Assert.AreEqual(tagsWebRequesterSpy.firstPage.results[1].name, initialTags[1].name);
+        Assert.AreEqual(tagsWebRequesterSpy.firstPage.results[2].name, initialTags[2].name);
         Assert.AreEqual(1, tagsWebRequesterSpy.lastPageRequested);
         Assert.AreEqual(1, tagsWebRequesterSpy.timesFetched);
     }
@@ -61,19 +61,19 @@ public class TagsApiManagerTest : MonoBehaviour
         tagsApiManager.tagsApiConsumer = tagsWebRequesterSpy;
         List<Tag> initialTags = await tagsApiManager.GetTags();
         Assert.AreEqual(3, initialTags.Count);
-        Assert.AreEqual("tag0", initialTags[0].name);
-        Assert.AreEqual("tag1", initialTags[1].name);
-        Assert.AreEqual("tag2", initialTags[2].name);
+        Assert.AreEqual(tagsWebRequesterSpy.firstPage.results[0].name, initialTags[0].name);
+        Assert.AreEqual(tagsWebRequesterSpy.firstPage.results[1].name, initialTags[1].name);
+        Assert.AreEqual(tagsWebRequesterSpy.firstPage.results[2].name, initialTags[2].name);
         Assert.AreEqual(1, tagsWebRequesterSpy.lastPageRequested);
         Assert.AreEqual(1, tagsWebRequesterSpy.timesFetched);
         List<Tag> moreTags = await tagsApiManager.LoadMoreTags();
         Assert.AreEqual(6, moreTags.Count);
-        Assert.AreEqual("tag0", moreTags[0].name);
-        Assert.AreEqual("tag1", moreTags[1].name);
-        Assert.AreEqual("tag2", moreTags[2].name);
-        Assert.AreEqual("tag3", moreTags[3].name);
-        Assert.AreEqual("tag4", moreTags[4].name);
-        Assert.AreEqual("tag5", moreTags[5].name);
+        Assert.AreEqual(tagsWebRequesterSpy.firstPage.results[0].name, moreTags[0].name);
+        Assert.AreEqual(tagsWebRequesterSpy.firstPage.results[1].name, moreTags[1].name);
+        Assert.AreEqual(tagsWebRequesterSpy.firstPage.results[2].name, moreTags[2].name);
+        Assert.AreEqual(tagsWebRequesterSpy.secondPage.results[0].name, moreTags[3].name);
+        Assert.AreEqual(tagsWebRequesterSpy.secondPage.results[1].name, moreTags[4].name);
+        Assert.AreEqual(tagsWebRequesterSpy.secondPage.results[2].name, moreTags[5].name);
         Assert.AreEqual(2, tagsWebRequesterSpy.lastPageRequested);
         Assert.AreEqual(2, tagsWebRequesterSpy.timesFetched);
     }
@@ -89,14 +89,13 @@ public class TagsApiManagerTest : MonoBehaviour
         Assert.AreEqual(2, tagsWebRequesterSpy.lastPageRequested);
         Assert.AreEqual(2, tagsWebRequesterSpy.timesFetched);
         List<Tag> moreTags = await tagsApiManager.LoadMoreTags();
-        Assert.AreEqual("tag0", moreTags[0].name);
-        Assert.AreEqual("tag1", moreTags[1].name);
-        Assert.AreEqual("tag2", moreTags[2].name);
-        Assert.AreEqual("tag3", moreTags[3].name);
-        Assert.AreEqual("tag4", moreTags[4].name);
-        Assert.AreEqual("tag5", moreTags[5].name);
-        Assert.AreEqual("tag6", moreTags[6].name);
-        Assert.AreEqual("tag7", moreTags[7].name);
+        Assert.AreEqual(tagsWebRequesterSpy.firstPage.results[0].name, moreTags[0].name);
+        Assert.AreEqual(tagsWebRequesterSpy.firstPage.results[1].name, moreTags[1].name);
+        Assert.AreEqual(tagsWebRequesterSpy.firstPage.results[2].name, moreTags[2].name);
+        Assert.AreEqual(tagsWebRequesterSpy.secondPage.results[0].name, moreTags[3].name);
+        Assert.AreEqual(tagsWebRequesterSpy.secondPage.results[1].name, moreTags[4].name);
+        Assert.AreEqual(tagsWebRequesterSpy.secondPage.results[2].name, moreTags[5].name);
+        Assert.AreEqual(tagsWebRequesterSpy.thirdPage.results[0].name, moreTags[6].name);
         Assert.AreEqual(8, moreTags.Count);
         Assert.AreEqual(3, tagsWebRequesterSpy.lastPageRequested);
         Assert.AreEqual(3, tagsWebRequesterSpy.timesFetched);

--- a/Tests/PlayMode/TexturesManagerTest.cs
+++ b/Tests/PlayMode/TexturesManagerTest.cs
@@ -1,12 +1,11 @@
-using System.Runtime.CompilerServices;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEditor;
 
 using ReupVirtualTwin.managerInterfaces;
-using ReupVirtualTwinTests.utils;
 using NUnit.Framework;
+using ReupVirtualTwinTests.instantiators;
 
 namespace ReupVirtualTwinTests.managers
 {

--- a/Tests/PlayMode/ZoomDhvCameraTest.cs
+++ b/Tests/PlayMode/ZoomDhvCameraTest.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using NUnit.Framework;
 using ReupVirtualTwin.behaviours;
+using ReupVirtualTwinTests.instantiators;
 using ReupVirtualTwinTests.utils;
 using Unity.Cinemachine;
 using UnityEngine;

--- a/Tests/PlayMode/reup.romulo.tests.playmode.asmdef
+++ b/Tests/PlayMode/reup.romulo.tests.playmode.asmdef
@@ -24,7 +24,8 @@
         "reup.romulo.tests.mocks",
         "Unity.InputSystem",
         "Unity.InputSystem.TestFramework",
-        "Unity.Cinemachine"
+        "Unity.Cinemachine",
+        "reup.romulo.tests.instantiators"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Tests/TestMocks/DelayTagsWebRequesterSpy.cs
+++ b/Tests/TestMocks/DelayTagsWebRequesterSpy.cs
@@ -1,6 +1,7 @@
 using ReupVirtualTwin.webRequestersInterfaces;
 using ReupVirtualTwin.dataModels;
 using System.Threading.Tasks;
+using ReupVirtualTwinTests.utils;
 
 namespace ReupVirtualTwinTests.mocks
 {
@@ -13,7 +14,7 @@ namespace ReupVirtualTwinTests.mocks
             count = 100000,
             next = "some-next-page-url",
             previous = "some-previous-page-url",
-            results = new Tag[1] { new Tag(){name = "tag0", id = "0", description="description0"}, },
+            results = TagFactory.CreateBulk(1).ToArray(),
         };
         private int delay;
 

--- a/Tests/TestMocks/TagsWebRequesterSpy.cs
+++ b/Tests/TestMocks/TagsWebRequesterSpy.cs
@@ -1,6 +1,8 @@
 using ReupVirtualTwin.webRequestersInterfaces;
 using System.Threading.Tasks;
 using ReupVirtualTwin.dataModels;
+using ReupVirtualTwinTests.utils;
+using System.Collections.Generic;
 
 namespace ReupVirtualTwinTests.mocks
 {
@@ -9,81 +11,35 @@ namespace ReupVirtualTwinTests.mocks
         public int lastPageRequested;
         public int lastPageSizeRequested;
         public int timesFetched = 0;
+        public PaginationResult<Tag> firstPage;
+        public PaginationResult<Tag> secondPage;
+        public PaginationResult<Tag> thirdPage;
 
-        private PaginationResult<Tag> firstPage = new PaginationResult<Tag>()
+        public TagsWebRequesterSpy()
         {
-            count = 8,
-            next = "url-for-page/2",
-            previous = null,
-            results = new Tag[] {
-                new Tag
-                {
-                    id = "0",
-                    name = "tag0",
-                    description = "tag0 description"
-                },
-                new Tag
-                {
-                    id = "1",
-                    name = "tag1",
-                    description = "tag1 description"
-                },
-                new Tag
-                {
-                    id = "2",
-                    name = "tag2",
-                    description = "tag2 description"
-                },
-            }
-        };
+            firstPage = new PaginationResult<Tag>()
+            {
+                count = 8,
+                next = "url-for-page/2",
+                previous = null,
+                results = TagFactory.CreateBulk(3).ToArray(),
+            };
+            secondPage = new PaginationResult<Tag>()
+            {
+                count = 8,
+                next = "url-for-page/3",
+                previous = "url-for-page/1",
+                results = TagFactory.CreateBulk(3).ToArray(),
 
-        private PaginationResult<Tag> secondPage = new PaginationResult<Tag>()
-        {
-            count = 8,
-            next = "url-for-page/3",
-            previous = "url-for-page/1",
-            results = new Tag[] {
-                new Tag
-                {
-                    id = "3",
-                    name = "tag3",
-                    description = "tag3 description"
-                },
-                new Tag
-                {
-                    id = "4",
-                    name = "tag4",
-                    description = "tag4 description"
-                },
-                new Tag
-                {
-                    id = "5",
-                    name = "tag5",
-                    description = "tag5 description"
-                },
-            }
-        };
-
-        private PaginationResult<Tag> thirdPage = new PaginationResult<Tag>()
-        {
-            count = 8,
-            next = null,
-            previous = "url-for-page/2",
-            results = new Tag[] {
-                new Tag
-                {
-                    id = "6",
-                    name = "tag6",
-                    description = "tag6 description"
-                },
-                new Tag
-                {
-                    id = "7",
-                    name = "tag7",
-                    description = "tag7 description"
-                },
-            }
-        };
+            };
+            thirdPage = new PaginationResult<Tag>()
+            {
+                count = 8,
+                next = null,
+                previous = "url-for-page/2",
+                results = TagFactory.CreateBulk(2).ToArray(),
+            };
+        }
 
         public Task<PaginationResult<Tag>> GetTags()
         {

--- a/Tests/TestMocks/reup.romulo.tests.mocks.asmdef
+++ b/Tests/TestMocks/reup.romulo.tests.mocks.asmdef
@@ -10,7 +10,9 @@
         "GUID:1f8fa41a8be0a6f4e8779e83989ae122",
         "GUID:db1051acd1be67444bdd582f8c8da4bd",
         "GUID:3e29f3cf4a29b6f4a8ecdaccb3a3a2ba",
-        "GUID:0da6763f50b07ec4c9363bdf3985cee5"
+        "GUID:0da6763f50b07ec4c9363bdf3985cee5",
+        "GUID:c8829a0ba3b964e4e9e556498da7797c",
+        "GUID:75469ad4d38634e559750d17036d5f7c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Tests/TestMocks/reup.romulo.tests.mocks.asmdef
+++ b/Tests/TestMocks/reup.romulo.tests.mocks.asmdef
@@ -14,7 +14,9 @@
         "GUID:c8829a0ba3b964e4e9e556498da7797c",
         "GUID:75469ad4d38634e559750d17036d5f7c"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/Tests/TestUtils/StubObjectTreeCreator.cs
+++ b/Tests/TestUtils/StubObjectTreeCreator.cs
@@ -1,8 +1,6 @@
-using ReupVirtualTwin.controllerInterfaces;
-using ReupVirtualTwin.controllers;
+using System.Collections.Generic;
+using System.Linq;
 using ReupVirtualTwin.dataModels;
-using ReupVirtualTwin.modelInterfaces;
-using ReupVirtualTwin.models;
 using UnityEngine;
 
 namespace ReupVirtualTwinTests.utils
@@ -14,33 +12,11 @@ namespace ReupVirtualTwinTests.utils
         public static string child1Id = "child1-id";
         public static string grandChild0Id = "grandChild0-id";
 
-        public static Tag[] parentTags = new Tag[3]
-        {
-        new Tag(){id="parent-tag-0"},
-        new Tag(){id="parent-tag-1"},
-        new Tag(){id="parent-tag-2"},
-        };
-        public static Tag commonChildrenTag = new Tag() { id = "common-children-tag" };
-        public static Tag[] child0Tags = new Tag[4]
-        {
-        new Tag(){id="child0-tag-0"},
-        new Tag(){id="child0-tag-1"},
-        new Tag(){id="child0-tag-2"},
-        commonChildrenTag,
-        };
-        public static Tag[] child1Tags = new Tag[4]
-        {
-        new Tag(){id="child1-tag-0"},
-        new Tag(){id="child1-tag-1"},
-        new Tag(){id="child1-tag-2"},
-        commonChildrenTag,
-        };
-        public static Tag[] grandChild0Tags = new Tag[3]
-        {
-        new Tag(){id="grandChild0-tag-0"},
-        new Tag(){id="grandChild0-tag-1"},
-        new Tag(){id="grandChild0-tag-2"},
-        };
+        public static Tag[] parentTags = TagFactory.CreateBulk(3).ToArray();
+        public static Tag commonChildrenTag = TagFactory.Create();
+        public static Tag[] child0Tags = TagFactory.CreateBulk(3).Concat(new[]{commonChildrenTag}).ToArray();
+        public static Tag[] child1Tags = TagFactory.CreateBulk(3).Concat(new[]{commonChildrenTag}).ToArray();
+        public static Tag[] grandChild0Tags = TagFactory.CreateBulk(3).ToArray();
 
         /// <summary>
         /// Creates a mock building with a parent, two children, a grandchild.
@@ -86,7 +62,7 @@ namespace ReupVirtualTwinTests.utils
             string objectId = $"object-{objectIndex}";
             GameObject obj = new(objectId);
             StubObjectCreatorUtils.AssignIdToObject(obj, objectId);
-            StubObjectCreatorUtils.AssignTagsToObject(obj, new Tag[1] { new Tag() { id = $"object-{objectIndex}-tag", name = $"object-{objectIndex}-tag" } });
+            StubObjectCreatorUtils.AssignTagsToObject(obj, new Tag[1] { new Tag() { id = objectIndex + 1000, name = $"object-{objectIndex}-tag" } });
             GameObject child = CreateDeepChainedLineOfObjects(depth - 1, objectIndex + 1);
             if (child != null)
             {

--- a/Tests/TestUtils/StubObjectTreeWithTagAtDifferentLevelsCreator.cs
+++ b/Tests/TestUtils/StubObjectTreeWithTagAtDifferentLevelsCreator.cs
@@ -12,10 +12,10 @@ namespace ReupVirtualTwinTests.utils
         public static string grandChild00Id = "grandChild00-id";
         public static string grandChild01Id = "grandChild01-id";
 
-        public static Tag tagX = new Tag() { id = "tag-x", name = "tag X" };
-        public static Tag tagY = new Tag() { id = "tag-y", name = "tag Y" };
-        public static Tag tagZ = new Tag() { id = "tag-z", name = "tag Z" };
-        public static Tag notPesentTag = new Tag() { id = "notPesentTag-id", name = "notPesentTag" };
+        public static Tag tagX = new Tag() { id = 1, name = "tag X" };
+        public static Tag tagY = new Tag() { id = 2, name = "tag Y" };
+        public static Tag tagZ = new Tag() { id = 3, name = "tag Z" };
+        public static Tag notPesentTag = new Tag() { id = -1, name = "notPesentTag" };
 
         /// <summary>
         /// Creates a mock object tree with an object with the following structure:

--- a/Tests/TestUtils/TagFactory.cs
+++ b/Tests/TestUtils/TagFactory.cs
@@ -7,8 +7,8 @@ using ReupVirtualTwin.dataModels;
 namespace ReupVirtualTwinTests.utils
 {
     public static class TagFactory
-
     {
+        static Faker<Tag> faker;
         public static Tag Create()
         {
             Faker<Tag> faker = GetFaker();
@@ -18,6 +18,10 @@ namespace ReupVirtualTwinTests.utils
         public static List<Tag> CreateBulk(int count)
         {
             Faker<Tag> faker = GetFaker();
+            return CreateBulk(count, faker);
+        }
+
+        public static List<Tag> CreateBulk(int count, Faker<Tag> faker){
             return Enumerable.Range(0, count).Select(_ => Create(faker)).ToList();
         }
 
@@ -28,9 +32,17 @@ namespace ReupVirtualTwinTests.utils
 
         static Faker<Tag> GetFaker()
         {
+            if (faker != null)
+            {
+                return faker;
+            }
+            faker = CreateFaker();
+            return faker;
+        }
+        public static Faker<Tag> CreateFaker(){
             var tagId = 0;
             return new Faker<Tag>().StrictMode(true)
-                .RuleFor(t => t.id, f => tagId++.ToString())
+                .RuleFor(t => t.id, f => tagId++)
                 .RuleFor(t => t.name, f => f.Name.FirstName())
                 .RuleFor(t => t.description, f => f.Lorem.Sentence())
                 .RuleFor(t => t.priority, f => f.Random.Int(0, 100));

--- a/Tests/TestUtils/reup.romulo.tests.utils.asmdef
+++ b/Tests/TestUtils/reup.romulo.tests.utils.asmdef
@@ -14,12 +14,11 @@
         "GUID:15c1dcf2b670848439ceff09bf17acd2",
         "GUID:0da6763f50b07ec4c9363bdf3985cee5",
         "GUID:3e29f3cf4a29b6f4a8ecdaccb3a3a2ba",
-        "GUID:75469ad4d38634e559750d17036d5f7c",
         "GUID:dc04f38471c3a459fb4d31124ee9127d",
-        "GUID:716a66b966d7f4d4dbe82763abab9053",
         "GUID:db1051acd1be67444bdd582f8c8da4bd",
         "GUID:40b5750f5722c3a489ac791a57baac05",
-        "GUID:993f0e698e8fb354b8eee1296bc5f2f6"
+        "GUID:993f0e698e8fb354b8eee1296bc5f2f6",
+        "GUID:75469ad4d38634e559750d17036d5f7c"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
[Reup506](https://macheight-reup.atlassian.net/browse/REUP-506?atlOrigin=eyJpIjoiYzZlYzQwM2MwZTZmNGJkYWIxMTBhZWJkMzg2Y2JkNDQiLCJwIjoiaiJ9)

As a developer, I want to have the action tags created in unity, so I can clean up the rest of the code to use the same patterns when dealing with tags.

AC:

Create a new tag type called Action

Create the 3 tags the database:

selectable

transformable

deletable

Update unity code to hardcode those 3 actions in their implementations

Update frontend code to support the new action tags

Models that are using previous action tags are still supported



